### PR TITLE
Add persistent file- and blob support for demo storage and support for before storage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,15 @@ Changelog
 4.2 - unreleased
 ----------------
 
+- Add support for a changes storage for demo storage (in addition to
+  the base storage). Local file and blob storage is supported.
+  [malthe]
+
+- Add support for before storage (via the ``zc.beforestorage`` package).
+  [malthe]
+
 - Make script suppression optional (via empty `scripts` parameter). Otherwise,
-  scripts for packages listed in `eggs` parameter will be generated. 
+  scripts for packages listed in `eggs` parameter will be generated.
   [aclark]
 
 - Support all RelStorage options, even future options. Used a simple pattern

--- a/README.txt
+++ b/README.txt
@@ -266,6 +266,14 @@ zeo-var
 Advanced options
 ----------------
 
+before-storage
+  Wraps the base storage in a "before storage" which sets it in
+  read-only mode from the time given (or "now" for the current time).
+
+  This option is normally used together with demo-storage for a
+  normally running site in order for changes to be made to the
+  database.
+
 client-home
   Sets the clienthome for the generated instance.
   Defaults to ${buildout:directory}/var/<name of the section>.
@@ -276,8 +284,25 @@ default-zpublisher-encoding
   Plone requires this to be set to `utf-8`.
 
 demo-storage
-  If 'on' it enables the `demostorage`. It is not compatible with
-  `blob-storage` or `rel-storage`.
+  If 'on' it enables the demo storage. By default, this is a
+  memory-based storage option; changes are not persisted (see the
+  demo-file-storage option to use a persistent storage for changes
+  made during the demonstration).
+
+  To use with a base storage option configured with a blob-storage,
+  you must set a demo-blob-storage.
+
+demo-file-storage
+  If provided, the filename where the ZODB data file for changes
+  committed during a demonstration will be stored.
+
+demo-blob-storage
+  If provided, the name of the directory where demonstration ZODB blob
+  data will be stored.
+
+  This storage may be connected to a demonstration file storage, or
+  used with the default memory-based demo storage (in this case you
+  might want to use a temporary directory).
 
 effective-user
   The name of the effective user for the Zope process. Defaults to not setting

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'mailinglogger',
         'zc.recipe.egg',
         'Zope2 >= 2.12.1',
+        'ZODB3 >= 3.9',
     ],
     zip_safe=False,
     entry_points = {'zc.buildout': ['default = %s:Recipe' % name]},

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -1,4 +1,4 @@
-==========================
+=========================
 plone.recipe.zope2instance
 ==========================
 
@@ -92,6 +92,7 @@ We should have a zope instance, with a basic zope.conf::
     # Blob-enabled FileStorage database
         <blobstorage>
           blob-dir .../sample-buildout/var/blobstorage
+          # FileStorage database
           <filestorage>
             path .../sample-buildout/var/filestorage/Data.fs
           </filestorage>
@@ -262,12 +263,15 @@ We should have a zope instance, with a basic zope.conf::
     <zodb_db main>
         # Main database
         cache-size 10000
-        # Demostorage
+    <BLANKLINE>
+    # DemoStorage
         <demostorage>
-          # FileStorage database
+    <BLANKLINE>
+        # FileStorage database
         <filestorage>
           path .../sample-buildout/var/newfs/Data.fs
         </filestorage>
+    <BLANKLINE>
         </demostorage>
         mount-point /
     </zodb_db>
@@ -312,10 +316,297 @@ We should have a zope instance, with a basic zope.conf without demostorage::
     # Blob-enabled FileStorage database
         <blobstorage>
           blob-dir .../sample-buildout/var/blobstorage
+          # FileStorage database
           <filestorage>
             path .../sample-buildout/var/newfs/Data.fs
           </filestorage>
         </blobstorage>
+        mount-point /
+    </zodb_db>
+    ...
+    <BLANKLINE>
+
+You can add file storage to the demo-storage to be able to keep
+changes::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... file-storage = newfs/Data.fs
+    ... demo-storage = on
+    ... demo-file-storage = demofs/Data.fs
+    ...
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print system(join('bin', 'buildout')),
+    Uninstalling instance.
+    Installing instance.
+
+We should have a zope instance, with a basic zope.conf::
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print zope_conf
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    <zodb_db main>
+        # Main database
+        cache-size 10000
+    <BLANKLINE>
+    # DemoStorage
+        <demostorage>
+    <BLANKLINE>
+        # FileStorage database
+        <filestorage base>
+          path .../sample-buildout/var/newfs/Data.fs
+        </filestorage>
+    <BLANKLINE>
+    <BLANKLINE>
+        # FileStorage database
+        <filestorage changes>
+          path .../sample-buildout/var/demofs/Data.fs
+        </filestorage>
+    <BLANKLINE>
+        </demostorage>
+        mount-point /
+    </zodb_db>
+    ...
+    <BLANKLINE>
+
+You can add a blob storage to the demo-storage as well::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... file-storage = newfs/Data.fs
+    ... blob-storage = ${buildout:directory}/var/blob
+    ... demo-storage = on
+    ... demo-file-storage = demofs/Data.fs
+    ... demo-blob-storage = ${buildout:directory}/var/demoblob
+    ...
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print system(join('bin', 'buildout')),
+    Uninstalling instance.
+    Installing instance.
+
+We should have a zope instance, with a basic zope.conf::
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print zope_conf
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+        <blobstorage base>
+          blob-dir .../sample-buildout/var/blob
+          # FileStorage database
+          <filestorage>
+            path .../sample-buildout/var/newfs/Data.fs
+          </filestorage>
+        </blobstorage>
+    ...
+        <blobstorage changes>
+          blob-dir .../sample-buildout/var/demoblob
+          # FileStorage database
+          <filestorage>
+            path .../sample-buildout/var/demofs/Data.fs
+          </filestorage>
+        </blobstorage>
+    ...
+
+Finally, you can add only a blob storage. Changes will then not be
+persisted on disk, but blob support will be available separately (it's
+not supported by the in-memory demostorage)::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... file-storage = newfs/Data.fs
+    ... demo-storage = on
+    ... demo-blob-storage = ${buildout:directory}/var/demoblob
+    ...
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print system(join('bin', 'buildout')),
+    Uninstalling instance.
+    Installing instance.
+
+We should have a zope instance, with a basic zope.conf::
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print zope_conf
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    <zodb_db main>
+        # Main database
+        cache-size 10000
+    <BLANKLINE>
+    # DemoStorage
+        <demostorage>
+    <BLANKLINE>
+        # FileStorage database
+        <filestorage base>
+          path .../sample-buildout/var/newfs/Data.fs
+        </filestorage>
+    <BLANKLINE>
+    <BLANKLINE>
+        # Blob-enabled FileStorage database
+        <blobstorage changes>
+          blob-dir .../sample-buildout/var/demoblob
+          <demostorage />
+        </blobstorage>
+    <BLANKLINE>
+        </demostorage>
+        mount-point /
+    </zodb_db>
+    ...
+
+BeforeStorage
+=============
+
+To have a BeforeStorage configuration, you can use before-storage::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... file-storage = newfs/Data.fs
+    ... before-storage = now
+    ...
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print system(join('bin', 'buildout')),
+    Uninstalling instance.
+    Installing instance.
+
+We should have a zope instance, with a basic zope.conf::
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print zope_conf
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    <zodb_db main>
+        # Main database
+        cache-size 10000
+    <BLANKLINE>
+    %import zc.beforestorage
+        # BeforeStorage
+        <before>
+          before now
+    <BLANKLINE>
+          # Blob-enabled FileStorage database
+          <blobstorage>
+            blob-dir .../sample-buildout/var/blobstorage
+            # FileStorage database
+            <filestorage>
+              path .../sample-buildout/var/newfs/Data.fs
+            </filestorage>
+          </blobstorage>
+    <BLANKLINE>
+        </before>
+        mount-point /
+    </zodb_db>
+    ...
+    <BLANKLINE>
+
+The before-storage option can be combined with a demo-storage::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... file-storage = newfs/Data.fs
+    ... before-storage = now
+    ... demo-storage = on
+    ...
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print system(join('bin', 'buildout')),
+    Uninstalling instance.
+    Installing instance.
+
+We should have a zope instance, with a basic zope.conf::
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print zope_conf
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    <zodb_db main>
+        # Main database
+        cache-size 10000
+    <BLANKLINE>
+        # DemoStorage
+        <demostorage>
+    <BLANKLINE>
+        %import zc.beforestorage
+        # BeforeStorage
+        <before>
+          before now
+    <BLANKLINE>
+          # Blob-enabled FileStorage database
+          <blobstorage>
+            blob-dir .../sample-buildout/var/blobstorage
+            # FileStorage database
+            <filestorage>
+              path .../sample-buildout/var/newfs/Data.fs
+            </filestorage>
+          </blobstorage>
+    <BLANKLINE>
+        </before>
+    <BLANKLINE>
+    <BLANKLINE>
+        </demostorage>
         mount-point /
     </zodb_db>
     ...
@@ -360,6 +651,7 @@ We should have a zope instance, with a basic zope.conf::
         # Blob-enabled FileStorage database
         <blobstorage>
           blob-dir .../sample-buildout/var/blob
+          # FileStorage database
           <filestorage>
             path .../sample-buildout/var/filestorage/Data.fs
           </filestorage>
@@ -426,6 +718,7 @@ We should have a zope instance, with a basic zope.conf::
 
 ZEO storage
 ===========
+
 If you want to connect to a zeo server you specify some additional properties
 for the plone.recipe.zope2instance recipe.
 
@@ -566,7 +859,7 @@ We should have a zope instance, with a basic zope.conf::
     ...
     <zodb_db main>
         ...
-        # Demostorage
+        # DemoStorage
         <demostorage>
         # ZEOStorage database
         <zeoclient>
@@ -586,7 +879,7 @@ We should have a zope instance, with a basic zope.conf::
     ...
     <BLANKLINE>
 
-Verify that demo-storage is correctly applied
+Verify that blob-storage is correctly applied
 
     >>> write('buildout.cfg',
     ... '''
@@ -633,6 +926,73 @@ We should have a zope instance, with a basic zope.conf::
     <BLANKLINE>
         </zeoclient>
         ...
+    </zodb_db>
+    ...
+    <BLANKLINE>
+
+Verify that demo-storage is correctly applied together with
+before-storage::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... zeo-client = yes
+    ... demo-storage = yes
+    ... before-storage = now
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print system(join('bin', 'buildout')),
+    Uninstalling instance.
+    Installing instance.
+
+We should have a zope instance, with a basic zope.conf::
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print zope_conf
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    <zodb_db main>
+        # Main database
+        cache-size 10000
+    <BLANKLINE>
+    # DemoStorage
+        <demostorage>
+    <BLANKLINE>
+        %import zc.beforestorage
+        # BeforeStorage
+        <before>
+          before now
+        # Blob-enabled ZEOStorage database
+          <zeoclient>
+            blob-dir .../sample-buildout/var/blobcache
+            shared-blob-dir no
+            server 8100
+            storage 1
+            name zeostorage
+            var .../sample-buildout/parts/instance/var
+            cache-size 128MB
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+          </zeoclient>
+        </before>
+    <BLANKLINE>
+        </demostorage>
+        mount-point /
     </zodb_db>
     ...
     <BLANKLINE>


### PR DESCRIPTION
The demo storage implementation has supported a "changes" storage since ZODB 3.9. This can be used to set up a persistent demonstration storage.

Used together with a before storage, one can wrap an otherwise changing database (e.g. ZEO) in a local demo storage that has blob support.

This changeset adds three new options to the recipe:
- before-storage
- demo-file-storage
- demo-blob-storage

All three can be used independently. Note that the last two require "demo-storage" to be enabled in order to take effect.

Documentation (README.txt) has been updated. There are tests for all the new options, plus combinations.
