### PR TITLE
Fix zcml load order of the optional locales directory. Translation overrides need to be loaded first.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 4.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix zcml load order of the optional locales directory. Translation overrides need to be loaded first.
+  [sunew]
 
 
 4.2.2 (2012-07-02)

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -627,7 +627,7 @@ class Recipe(Scripts):
 
         if locales:
             locales_path = locales.strip()
-            path=os.path.join(includes_path, "997-locales-configure.zcml")
+            path=os.path.join(includes_path, "001-locales-configure.zcml")
             open(path, "w").write(
                 locales_zcml % dict(directory=locales_path)
                 )
@@ -636,7 +636,7 @@ class Recipe(Scripts):
                 os.mkdir(locales_path)
 
         if zcml:
-            n = 0
+            n = 1 # 001 is reserved for an optional locales-configure
             package_match = re.compile('\w+([.]\w+)*$').match
             for package in zcml:
                 n += 1


### PR DESCRIPTION
Changed the naming of the "locales-configure.zcml" file to make it load first.
It seems to work with "000-..." but I'm not quite sure if that's a good idea. Using "001-.." and starting the zcml package with "002-..." instead, to be sure.
