### PR TITLE
Add the 'drop-cache-rather-verify' option to zeo client config + remove empty lines in zope.conf generation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,13 @@ Changelog
 4.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Expose 'drop-cache-rather-verify' ZEO client option which indicates that
+  the cache should be dropped rather than verified when the verification 
+  optimization is not available (e.g. when the ZEO server restarted).
+  [runyaga]
 
+- Strip all empty lines out of zeo.conf to provide more compact view.
+  [runyaga]
 
 4.2.3 (2012-08-04)
 ------------------

--- a/README.txt
+++ b/README.txt
@@ -285,6 +285,11 @@ zeo-var
   Used in the ZEO storage snippets to configure the ZEO var folder.
   Defaults to $INSTANCE_HOME/var.
 
+zeo-drop-cache-rather-verify
+  Indicates that the cache should be dropped rather than verified when
+  the verification optimization is not available (e.g. when the ZEO server
+  restarted). Defaults to 'False'.
+
 Advanced options
 ----------------
 

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -388,6 +388,10 @@ class Recipe(Scripts):
                 raise ValueError('You cannot use both ZEO and RelStorage '
                     'at the same time.')
 
+            zeo_drop_cache_rather_verify = options.get('zeo-drop-cache-rather-verify', '')
+            if zeo_drop_cache_rather_verify:
+                zeo_drop_cache_rather_verify = 'drop-cache-rather-verify %s' % \
+                        zeo_drop_cache_rather_verify
             zeo_var_dir = options.get('zeo-var',
                                       os.path.join(instance_home, 'var'))
             zeo_client_client = options.get('zeo-client-client', '')
@@ -438,6 +442,7 @@ class Recipe(Scripts):
                 zeo_client_client = zeo_client_client,
                 zeo_storage = zeo_storage,
                 zeo_var_dir=zeo_var_dir,
+                zeo_drop_cache_rather_verify = zeo_drop_cache_rather_verify,
                 zeo_client_min_disconnect_poll=zeo_client_min_disconnect_poll,
                 zeo_client_max_disconnect_poll=zeo_client_max_disconnect_poll,
                 )
@@ -508,7 +513,7 @@ class Recipe(Scripts):
                                     access_event_log = access_event_log,
                                     z_log_level = z_log_level,
                                     default_zpublisher_encoding = default_zpublisher_encoding,
-                                    storage_snippet = storage_snippet.strip(),
+                                    storage_snippet = storage_snippet,
                                     port_base = port_base,
                                     http_address = http_address,
                                     http_force_connection_close = http_force_connection_close,
@@ -528,6 +533,7 @@ class Recipe(Scripts):
                                     enable_products = enable_products,
                                     zope_conf_additional = zope_conf_additional,)
 
+        zope_conf = '\n'.join([l for l in zope_conf.splitlines() if l.rstrip()])
         zope_conf_path = os.path.join(location, 'etc', 'zope.conf')
         try:
             fd = open(zope_conf_path, 'w')
@@ -783,6 +789,7 @@ zeo_storage_template="""
       %(zeo_client_client)s
       %(zeo_client_min_disconnect_poll)s
       %(zeo_client_max_disconnect_poll)s
+      %(zeo_drop_cache_rather_verify)s
     </zeoclient>
 """.strip()
 
@@ -802,6 +809,7 @@ zeo_blob_storage_template="""
       %(zeo_client_client)s
       %(zeo_client_min_disconnect_poll)s
       %(zeo_client_max_disconnect_poll)s
+      %(zeo_drop_cache_rather_verify)s
     </zeoclient>
 """.strip()
 


### PR DESCRIPTION
Quite simple change which adds an advanced ZEO configuration option.  Also strip out the empty lines in zope.conf so the configuration is more compact/easier to read.
