### PR TITLE
Always wrap contents of zcml-additional with a <configure /> node.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 4.2.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Always wrap contents of zcml-additional with a <configure /> node.
+  This makes it possible to use += assignments with zcml-additional.
+  [lgraf]
 
 
 4.2.14 (2014-03-02)

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -677,6 +677,7 @@ class Recipe(Scripts):
                     os.mkdir(includes_path)
 
         if additional_zcml:
+            additional_zcml = additional_zcml_template % additional_zcml
             path=os.path.join(includes_path, "999-additional-overrides.zcml")
             open(path, "w").write(additional_zcml.strip())
 
@@ -1017,5 +1018,12 @@ locales_zcml = """\
 <configure xmlns="http://namespaces.zope.org/zope"
            xmlns:i18n="http://namespaces.zope.org/i18n">
     <i18n:registerTranslations directory="%(directory)s" />
+</configure>
+"""
+
+# Template used for additional ZCML
+additional_zcml_template = """\
+<configure xmlns="http://namespaces.zope.org/zope">
+    %s
 </configure>
 """


### PR DESCRIPTION
This makes it possible to use `+=` assignments with `zcml-additional`.

Currently, the contents of `zcml-additional` are dumped as-is in `999-additional-overrides.zcml`. This means that you can't use `zcml-additional +=` assignments to add to an instance's additional ZCML from multiple places, because you will end up with a `999-additional-overrides.zcml` that contains multiple top level nodes (which isn't valid XML).

In this PR I wrap the contents of `zcml-additional` in `<configure />` node (including the Zope XMLNS) before writing them to the file.

This is done unconditionally, so even if `zcml-additional` only contains one element, it will be wrapped. However, because `<configure />` directives can be nested to arbitrary depths (see [`zope.configuration.zopeconfigure`](https://github.com/zopefoundation/zope.configuration/blob/master/src/zope/configuration/zopeconfigure.py), this should not be a problem, and the simplicity of the change outweighs the possible redundancy in my opinion. 
