### PR TITLE
If 'demo-file-storage' is set, but 'demo-storage' is off, do not raise an Exception

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 4.2.15 (unreleased)
 -------------------
 
+- If ''demo-file-storage' is set, but 'demo-storage' is off, do not
+  raise an exception
+  [frapell]
 - Always wrap contents of zcml-additional with a <configure /> node.
   This makes it possible to use += assignments with zcml-additional.
   [lgraf]

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -514,9 +514,6 @@ class Recipe(Scripts):
                     )
             else:
                 storage_snippet = demo_storage_template % storage_snippet
-        elif 'demo-file-storage' in options:
-            raise ValueError("Must enable demo-storage to use demo-file-storage.")
-
 
         zodb_tmp_storage = options.get('zodb-temporary-storage',
                                        zodb_temporary_storage_template)


### PR DESCRIPTION
If you are extending a profile which uses demo-storage, there's no way to disable it.

Setting demo-storage = off is not enough because demo-file-storage is still set and there is no way to unset it, which causes buildout to raise an exception.
