### PR TITLE
Added `zope-conf-imports` option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 4.2.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Added `zope-conf-imports` option to easily import ZConfig components
+  within zope.conf using %import syntax.
+  [avoinea]
 
 
 4.2.16 (2014-11-01)

--- a/README.rst
+++ b/README.rst
@@ -455,6 +455,18 @@ zope-conf
   A relative or absolute path to a `zope.conf` file. If this is given, many of
   the options in the recipe will be ignored.
 
+zope-conf-imports
+  You can define custom sections within zope.conf using the ZConfig API.
+  But, in order for Zope to understand your custom sections, you'll have to
+  import the python packages that define these custom sections using `%import`
+  syntax.
+
+  Example::
+
+    zope-conf-imports =
+      mailinglogger
+      eea.graylogger
+
 zope-conf-additional
   Give additional lines to `zope.conf`. Make sure you indent any lines after
   the one with the parameter.

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -5,6 +5,9 @@ versions = versions
 develop = .
 parts = test
 
+[versions]
+setuptools = 7.0
+
 [test]
 recipe = zc.recipe.testrunner
 eggs = plone.recipe.zope2instance

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -141,6 +141,13 @@ class Recipe(Scripts):
         if zope_conf_path is not None:
             return
 
+        imports = options.get('zope-conf-imports', '')
+        if imports:
+            imports = imports.split('\n')
+            # Filter out empty lines
+            imports = [i for i in imports if i]
+        imports_lines = '\n'.join(('%%import %s' % i for i in imports))
+
         products = options.get('products', '')
         if products:
             products = products.split('\n')
@@ -536,6 +543,7 @@ class Recipe(Scripts):
 
         zope_conf = template % dict(instance_home = instance_home,
                                     client_home = client_home,
+                                    imports_lines = imports_lines,
                                     paths_lines = paths_lines,
                                     products_lines = products_lines,
                                     debug_mode = debug_mode,
@@ -965,6 +973,7 @@ environment_template = """
 
 # The template used to build zope.conf
 zope_conf_template="""\
+%(imports_lines)s
 %%define INSTANCEHOME %(instance_home)s
 instancehome $INSTANCEHOME
 %%define CLIENTHOME %(client_home)s

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -1770,6 +1770,45 @@ We should have a zope instance script with the custom config file::
     >>> open(instance_path).read()
     "...plone.recipe.zope2instance.ctl.main(...['-C', '/some/path/my.conf']..."
 
+Custom Zope Conf Imports
+========================
+`zope-conf-imports` is an option that allows you to import python packages that
+define custom zope.conf sections using ZConfig API.
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... zope-conf-imports =
+    ...   mailinglogger
+    ...   eea.graylogger
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print system(join('bin', 'buildout')),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '...instance'.
+    Generated interpreter '.../parts/instance/bin/interpreter'.
+
+We should have a zope instance, with custom imports::
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print zope_conf
+    %import mailinglogger
+    %import eea.graylogger
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    <BLANKLINE>
 
 Resources directory
 ===================


### PR DESCRIPTION
- Added `zope-conf-imports` option to easily import ZConfig components
  within zope.conf using %import syntax.