### PR TITLE
Better support for running Plone on PaaS providers such as Heroku

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New features:
 - Added support for setting `instance-home` option.
   [zupo]
 
+- Added support for setting CGI environment variables.
+  [zupo]
+
 Bug fixes:
 
 - *add item here*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Added support for setting `instance-home` option.
+  [zupo]
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -341,6 +341,10 @@ before-storage
   normally running site in order for changes to be made to the
   database.
 
+instance-home
+  Sets the instancehome for the generated instance.
+  Defaults to ${buildout:directory}/parts/<name of the section>.
+
 client-home
   Sets the clienthome for the generated instance.
   Defaults to ${buildout:directory}/var/<name of the section>.

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,13 @@ environment-vars
       zope_i18n_allowed_languages en
       zope_i18n_compile_mo_files true
 
+cgi-environment-vars
+  Define arbitrary key-value pairs for use as CGI environment variables during
+  Zope's run cycle. Example::
+
+    cgi-environment-vars =
+      HTTPS ON
+
 initialization
    Specify some Python initialization code to include within the generated
    ``sitecustomize.py`` script (Buildout >= 1.5) or within the instance script

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -161,7 +161,7 @@ class Recipe(Scripts):
         if not os.path.exists(var_dir):
             os.makedirs(var_dir)
 
-        instance_home = location
+        instance_home = options.get('instance-home', location)
         client_home = options.get('client-home', os.path.join(var_dir,
                                                               self.name))
         if not os.path.exists(client_home):

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -1788,6 +1788,44 @@ Our environment variables should be set now::
     >>> re.search(env_vars, zope_conf).group('vars')
     'TZ US/Eastern\nTMP /var/tmp\nDISABLE_PTS True'
 
+We can also specify CGI environment variables for Zope.  This comes handy when
+hosting on PaaS providers, such as Heroku, where we don't have a reverse-proxy
+in front of Zope. For example, we can configure Zope to run in HTTPS mode::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... cgi-environment-vars = HTTPS ON
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print system(join('bin', 'buildout')),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '...instance'.
+    Generated interpreter '.../parts/instance/bin/interpreter'.
+    ...
+
+Our CGI environment variables should be set now::
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print zope_conf
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    <cgi-environment>
+      HTTPS ON
+    </cgi-environment>
+    ...
 
 HTTP server
 ===========


### PR DESCRIPTION
Some containerized PaaS providers run the build process in a different location than where they run the end product, i.e. the app server.

For example, when I run buildout on Heroku, the resulting zope.conf file contains a line like so:

```
%define INSTANCEHOME /tmp/build_857f615d508f92191ca58c6947e2def8/parts/instance
```

This path does not exist in the production environment, as there, the instance home is at `/app/parts/instance`.

This commit allows me to set the instance home as an option inside the plone.recipe.zope2instance section in my buildout.cfg file:

```
[instance]
recipe = plone.recipe.zope2instance
instance-home = /app/parts/instance
client-home = /app/var/instance
```