### PR TITLE
Fix WSGI initialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ New features:
 Bug fixes:
 
 - Super user password created on Python 3 can now be read by Zope.
+- Fix WSGI initialization [tschorr]
 
 
 5.0.0 (2018-01-27)

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -612,7 +612,6 @@ class Recipe(Scripts):
         reqs = [self.options.get('control-script', self.name)]
         if self.wsgi:
             reqs.extend(['plone.recipe.zope2instance.wsgi', 'waitress_main'])
-            options['initialization'] = wsgi_initialization
         else:
             reqs.extend(['plone.recipe.zope2instance.ctl', 'main'])
         reqs = [tuple(reqs)]
@@ -674,13 +673,17 @@ class Recipe(Scripts):
                 script_arguments=script_arguments,
                 )
         else:
+            if self.wsgi:
+                initialization = wsgi_initialization % options
+            else:
+                initialization = options['initialization'] % options
             return zc.buildout.easy_install.scripts(
                 dest=dest,
                 reqs=reqs,
                 working_set=working_set,
                 executable=options['executable'],
                 extra_paths=extra_paths,
-                initialization=options['initialization'] % options,
+                initialization=initialization,
                 arguments=script_arguments,
                 interpreter=interpreter,
                 relative_paths=self._relative_paths,)


### PR DESCRIPTION
WSGI initialization in scripts is broken when using Python 3 and recent zc.buildout versions, s. https://github.com/plone/Products.CMFPlone/issues/2385.