### PR TITLE
readd the zodb_tmp_storage placeholder into the wsgi template

### DIFF
--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -1076,6 +1076,8 @@ verbose-security %(verbose_security)s
     mount-point /
 </zodb_db>
 
+%(zodb_tmp_storage)s
+
 %(python_check_interval)s
 
 %(zope_conf_additional)s


### PR DESCRIPTION
Wanted to get the zodb tempstorage config back for wsgi too for session handling. Since it was removed on purpose, I am not sure this is harmless. Could someone clarify please?