### PR TITLE
Improved error message for invalid comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- Improved error message for invalid comments in zcml variable assignment
+- Improved error message for invalid comments in zcml variable assignment; fixes #46
   [tobiasherp]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Improved error message for invalid comments in zcml variable assignment
+  [tobiasherp]
 
 
 4.4.0 (2018-04-24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- Improved error message for invalid comments in zcml variable assignment; fixes #46
+- Make comments in zcml values work, even if not starting at the beginning of the line;
+  before, we had a confusing error message. Fixes #46
   [tobiasherp]
 
 

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -758,6 +758,15 @@ class Recipe(Scripts):
             n = 1 # 001 is reserved for an optional locales-configure
             package_match = re.compile('\w+([.]\w+)*$').match
             for package in zcml:
+                if package.startswith('#'):
+                    comment_snippet = zcml[n-1:n+5]
+                    if zcml[n+5:]:
+                        comment_snippet.append('(...)')
+                    comment_snippet = ' '.join(comment_snippet)
+                    raise ValueError('Invalid comment in zcml assignment'
+                                     ' (must start in first column; something like'
+                                     ' %(comment_snippet)r)'
+                                     % locals())
                 n += 1
                 orig = package
                 if ':' in package:

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -759,13 +759,17 @@ class Recipe(Scripts):
             package_match = re.compile('\w+([.]\w+)*$').match
             for package in zcml:
                 if package.startswith('#'):
-                    comment_snippet = zcml[n-1:n+5]
-                    if zcml[n+5:]:
+                    if package == '#':  # likely space and text following:
+                        nend = n + 1
+                    else:
+                        nend = n
+                    comment_snippet = zcml[n-1:nend]
+                    if zcml[nend:]:
                         comment_snippet.append('(...)')
                     comment_snippet = ' '.join(comment_snippet)
                     raise ValueError('Invalid comment in zcml assignment'
-                                     ' (must start in first column; something like'
-                                     ' %(comment_snippet)r)'
+                                     ' (must start in first column); '
+                                     'something like %(comment_snippet)r'
                                      % locals())
                 n += 1
                 orig = package

--- a/src/plone/recipe/zope2instance/__init__.py
+++ b/src/plone/recipe/zope2instance/__init__.py
@@ -761,6 +761,8 @@ class Recipe(Scripts):
                 if package.startswith('#'):
                     if package == '#':  # likely space and text following:
                         nend = n + 1
+                    elif ' ' in package:  # OK: line-based split!
+                        continue
                     else:
                         nend = n
                     comment_snippet = zcml[n-1:nend]


### PR DESCRIPTION
When invalid comments are found in the assigment to the zcml variable
(i.e. those prepended by whitespace in the same line), the recipe
complains about "Invalid zcml" and a "package" which is named
'#firstword' or (even worse, if the '#' is followed by whitespace) '#',
and the rest of the comment is silently taken as package names as well.
(issue 46)

This change explicitly creates a hopefully much more useful error
message.