### PR TITLE
Fix `bin/zinstance` script for `wsgi=on`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.5
   - 3.6
 install:
-  - pip install setuptools==33.1.1 zc.buildout==2.5.3
+  - pip install setuptools==33.1.1 zc.buildout==2.12.1
   - buildout bootstrap
   - bin/buildout -t 3
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ python:
   - 3.5
   - 3.6
 install:
-  - pip install setuptools==33.1.1 zc.buildout==2.12.1
-  - buildout bootstrap
-  - bin/buildout -t 3
+  - pip install tox-travis
 script:
-  - bin/test -vv --auto-color
+  - tox
 cache:
   pip: true
-  directories:
-    - eggs/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,9 +20,13 @@ Bug fixes:
 - Move Recipe from __init__.py to a new module to get rid of the dependency on
   zc.recipe.egg in control scripts
   [tschorr]
-- Make use of changes to Zope WSGI logging (https://github.com/zopefoundation/Zope/pull/280,
-  https://github.com/zopefoundation/Zope/pull/276), use Zope2 WSGI startup code.
+- Make use of changes to Zope WSGI logging
+  (`#280` <https://github.com/zopefoundation/Zope/pull/280>`_,
+  `#276`<https://github.com/zopefoundation/Zope/pull/276>`_),
+  use Zope2 WSGI startup code.
   [tschorr]
+- Fix the tests on Python 3 when running via tox or TravisCI.
+  [icemac]
 
 
 5.0.0 (2018-01-27)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,6 @@
 [buildout]
 index = https://pypi.python.org/simple/
-extends = https://raw.githubusercontent.com/zopefoundation/Zope/4.0b2/versions-prod.cfg
+extends = https://zopefoundation.github.io/Zope/releases/master/versions-prod.cfg
 versions = versions
 develop = .
 parts = test

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,11 @@ setup(
         'ZODB >= 5.1.1',
         'ZEO',
     ],
+    extras_require={
+        'test': [
+            'zope.testrunner',
+        ],
+    },
     zip_safe=False,
     entry_points={'zc.buildout': ['default = %s.recipe:Recipe' % name]},
 )

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -638,7 +638,7 @@ class Recipe(Scripts):
 
         options['zope-conf'] = zope_conf_path
         arguments = ["-C", zope_conf_path, '-p', program_path] \
-            if not self.wsgi else []
+            if not self.wsgi else ['ignored']
         if zopectl_umask:
             arguments.extend(["--umask", int(zopectl_umask, 8)])
         script_arguments = ('\n        ' + repr(arguments) +

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -29,8 +29,7 @@ Let's run it::
 
     >>> print(system(join('bin', 'buildout'))),
     Installing wsgi.py.
-    Generated script '...wsgi.py'.
-    ...
+    Generated script '...wsgi.py'...
 
 We should have a wsgi.py part, with a basic zope.conf::
 

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -33,8 +33,7 @@ Let's run it::
     >>> print(system(join('bin', 'buildout'))),
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -160,8 +159,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Our FTP server should be set up now::
 
@@ -198,8 +196,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Our WebDAV server should be set up now::
 
@@ -237,8 +234,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Our WebDAV server should be set up now::
 
@@ -280,8 +276,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -332,8 +327,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf without demostorage::
 
@@ -385,8 +379,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -446,8 +439,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -500,8 +492,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -562,8 +553,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -623,8 +613,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -687,8 +676,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -746,8 +734,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -812,8 +799,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -871,8 +857,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -922,8 +907,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -984,8 +968,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -1041,8 +1024,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -1098,8 +1080,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -1156,8 +1137,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -1226,8 +1206,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -1281,8 +1260,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with a basic zope.conf::
 
@@ -1343,8 +1321,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Now zope.conf should include the custom storage wrapper::
 
@@ -1401,8 +1378,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with the custom event log::
 
@@ -1459,8 +1435,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with the mailing logger::
 
@@ -1521,8 +1496,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with the custom event log::
 
@@ -1571,8 +1545,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with no access log::
 
@@ -1611,8 +1584,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with no access log::
 
@@ -1661,8 +1633,7 @@ Let's run the buildout::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Now let's check that we have a zope instance, with the custom site.zcml::
 
@@ -1703,8 +1674,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Our environment variables should be set now::
 
@@ -1743,8 +1713,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Our environment variables should be set now::
 
@@ -1777,8 +1746,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Our environment variables should be set now::
 
@@ -1814,8 +1782,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 And check it::
 
@@ -1859,8 +1826,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Relative paths in scripts
 =========================
@@ -1883,8 +1849,7 @@ The recipe supports the generation of scripts with relative paths.
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 Our generated script now has a reference to the relative path.
 
@@ -1921,8 +1886,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance script with the custom config file::
 
@@ -1958,8 +1922,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should have a zope instance, with custom imports::
 
@@ -1998,8 +1961,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 The directory should have been generated, and zope config created::
 
@@ -2041,8 +2003,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 The directory should have been generated, and zope config created::
 
@@ -2084,8 +2045,7 @@ Let's run it::
     Uninstalling instance.
     Installing instance.
     Generated script '...instance'.
-    Generated interpreter '.../parts/instance/bin/interpreter'.
-    ...
+    Generated interpreter '.../parts/instance/bin/interpreter'...
 
 We should see the given initialization commands included in the instance
 script::

--- a/tox.ini
+++ b/tox.ini
@@ -9,20 +9,19 @@ envlist =
 skip_missing_interpreters = False
 
 [testenv]
+usedevelop = true
 commands =
-    {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} bootstrap
-    {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} -n install test
-    coverage run {envbindir}/test --all {posargs:-vc}
-skip_install = true
+    coverage run {envbindir}/zope-testrunner --test-path=src
 deps =
-    setuptools==33.1.1
-    zc.buildout
+    -r https://zopefoundation.github.io/Zope/releases/4.0b5/requirements-full.txt
+    .[test]
     coverage
 setenv =
     COVERAGE_FILE=.coverage.{envname}
 
 [testenv:coverage]
 basepython = python2.7
+skip_install = true
 deps = coverage
 setenv =
     COVERAGE_FILE=.coverage
@@ -35,5 +34,6 @@ commands =
 
 [testenv:flake8]
 basepython = python2.7
+skip_install = true
 deps = flake8
 commands = flake8 --doctests src setup.py


### PR DESCRIPTION
Stripping of the first argument of `argv` is already done again in https://github.com/zopefoundation/Zope/blob/master/src/Zope2/Startup/serve.py#L136 which is called by `Zope2.Startup.serve.main`.

This extends the fix of #44, so I think no change log entry is needed.