### PR TITLE
Pass wsgi flag to ctl script instead of guessing based on presence of ZServer

### DIFF
--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -648,6 +648,8 @@ class Recipe(Scripts):
         arguments = ["-C", zope_conf_path, '-p', program_path]
         if zopectl_umask:
             arguments.extend(["--umask", int(zopectl_umask, 8)])
+        if self.wsgi:
+            arguments.append("--wsgi")
         script_arguments = ('\n        ' + repr(arguments) +
                             '\n        + sys.argv[1:]')
 
@@ -1066,7 +1068,6 @@ verbose-security %(verbose_security)s
 %(port_base)s
 %(effective_user)s
 %(environment_vars)s
-%(deprecation_warnings)s
 
 %(mailinglogger_import)s
 

--- a/src/plone/recipe/zope2instance/tests/test_wsgischema.py
+++ b/src/plone/recipe/zope2instance/tests/test_wsgischema.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 
-from plone.recipe.zope2instance.ctl import ZopeCtlOptions
+from plone.recipe.zope2instance.ctl import WSGICtlOptions
 import os
 import tempfile
 import unittest
@@ -32,7 +32,7 @@ TEMPVAR = os.path.join(TEMPNAME, "var")
 def getSchema():
     global _SCHEMA
     if not _SCHEMA:
-        opts = ZopeCtlOptions()
+        opts = WSGICtlOptions()
         opts.load_schema()
         _SCHEMA = opts.schema
     return _SCHEMA


### PR DESCRIPTION
This gets Plone starting up with both ZServer and WSGI in Python 2.