### PR TITLE
Add a new threads option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add new option 'threads' used to specify the number of workers for both
+  waitress + ZServer, and a deprecation warning for 'zserver-threads'.
+  [tschorr]
 
 Bug fixes:
 

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -1,7 +1,9 @@
-=====================
-Test wsgi.py creation
-=====================
+===========================
+Test wsgi instance creation
+===========================
 
+Test default configuration
+==========================
 
     >>> from __future__ import print_function
     >>> from zc.buildout.testing import *
@@ -15,10 +17,10 @@ plone.recipe.zope2instance::
     >>> write('buildout.cfg',
     ... '''
     ... [buildout]
-    ... parts = wsgi.py
+    ... parts = instance
     ... find-links = %(sample_buildout)s/eggs
     ...
-    ... [wsgi.py]
+    ... [instance]
     ... recipe = plone.recipe.zope2instance
     ... eggs =
     ... user = me:me
@@ -28,18 +30,18 @@ plone.recipe.zope2instance::
 Let's run it::
 
     >>> print(system(join('bin', 'buildout'))),
-    Installing wsgi.py.
-    Generated script '...wsgi.py'...
+    Installing instance.
+    Generated script '...instance'...
 
-We should have a wsgi.py part, with a basic zope.conf::
+We should have an instance part, with a basic zope.conf::
 
-    >>> instance = os.path.join(sample_buildout, 'parts', 'wsgi.py')
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
     >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
     >>> zope_conf = zope_conf.replace('\\', '/')
     >>> print(zope_conf)
-    %define INSTANCEHOME .../sample-buildout/parts/wsgi.py
+    %define INSTANCEHOME .../sample-buildout/parts/instance
     instancehome $INSTANCEHOME
-    %define CLIENTHOME .../sample-buildout/var/wsgi.py
+    %define CLIENTHOME .../sample-buildout/var/instance
     clienthome $CLIENTHOME
     debug-mode off
     security-policy-implementation C
@@ -67,3 +69,91 @@ We should have a wsgi.py part, with a basic zope.conf::
         container-class Products.TemporaryFolder.TemporaryContainer
     </zodb_db>
     python-check-interval 1000
+
+The buildout has also created an INI file containing the waitress configuration:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
+    >>> print(wsgi_ini)
+    [server:main]
+    use = egg:waitress#main
+    listen = 0.0.0.0:8080
+    threads = 4
+    <BLANKLINE>
+    [app:zope]
+    use = egg:Zope#main
+    zope_conf = .../sample-buildout/parts/instance/etc/zope.conf
+    <BLANKLINE>
+    [pipeline:main]
+    pipeline =
+        egg:Zope#httpexceptions
+        zope
+    <BLANKLINE>
+    [loggers]
+    keys = root, plone
+    <BLANKLINE>
+    [handlers]
+    keys = console
+    <BLANKLINE>
+    [formatters]
+    keys = generic
+    <BLANKLINE>
+    [logger_root]
+    level = INFO
+    handlers = console
+    <BLANKLINE>
+    [logger_plone]
+    level = DEBUG
+    handlers =
+    qualname = plone
+    <BLANKLINE>
+    [handler_console]
+    class = StreamHandler
+    args = (sys.stderr,)
+    level = NOTSET
+    formatter = generic
+    <BLANKLINE>
+    [formatter_generic]
+    format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
+    <BLANKLINE>
+
+Custom WSGI options
+=================
+
+Let's create another buildout configuring a custom port and a custom number of workers::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... http-address = localhost:6543
+    ... threads = 3
+    ... wsgi = on
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '.../sample-buildout/bin/instance'.
+    ...
+
+The buildout has updated our INI file:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
+    >>> print(wsgi_ini)
+    [server:main]
+    use = egg:waitress#main
+    listen = localhost:6543
+    threads = 3
+    <BLANKLINE>
+    [app:zope]
+    ...

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -1853,8 +1853,6 @@ The 'zserver-threads' option is deprecated but still working:
 
 Run it::
 
-    >>> import warnings
-    >>> warnings.simplefilter('error')
     >>> print(system(join('bin', 'buildout')))
     Uninstalling instance.
     Installing instance.

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -1801,6 +1801,78 @@ And check it::
     </http-server>
     ...
 
+Configuring ZServer workers is also possible using the 'threads' option:
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... threads = 3
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '...instance'.
+    Generated interpreter '.../parts/instance/bin/interpreter'...
+
+And check it::
+
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print(zope_conf)
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    zserver-threads 3
+    ...
+    <http-server>
+    ...
+
+The 'zserver-threads' option is deprecated but still working:
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... zserver-threads = 3
+    ... ''' % options)
+
+Run it::
+
+    >>> import warnings
+    >>> warnings.simplefilter('error')
+    >>> print(system(join('bin', 'buildout')))
+    Uninstalling instance.
+    Installing instance.
+    Generated script '...instance'.
+    Generated interpreter '.../parts/instance/bin/interpreter'...
+
+And check it::
+
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print(zope_conf)
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    zserver-threads 3
+    ...
+    <http-server>
+    ...
+
 Edge Cases
 ==========
 


### PR DESCRIPTION
* Add a new option named `threads` to specify the number of worker threads for both waitress and ZServer. 
* Slightly change the semantics for specifying the http address for waitress to allow for more flexibility for the host portion. 
* Add + update tests