### PR TITLE
logger level for WSGI Plone logger set to INFO in order to restore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 6.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- log level for Plone WSGI logger changed to INFO making the logging less
+  verbose
+  [ajung]
 
 
 6.1.0 (2018-12-28)

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -1194,7 +1194,7 @@ level = INFO
 handlers = console
 
 [logger_plone]
-level = DEBUG
+level = INFO
 handlers =
 qualname = plone
 


### PR DESCRIPTION
the "old" amount of logging