### PR TITLE
Add http-fast-listen option for waitress

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,15 @@ Changelog
 
 .. towncrier release notes start
 
+6.1.2 (unreleased)
+------------------
+
+Bug fixes:
+
+- restore http-fast-listen for waitress (`#71 <https://github.com/plone/plone.recipe.zope2instance/issues/71>`_)
+  [tschorr]
+
+
 6.1.1 (2019-02-08)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'Zope >= 4.0b1',
         'ZODB >= 5.1.1',
         'ZEO',
-        'waitress >= 1.1.1',
+        'waitress >= 1.2.0',
         'Paste',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Zope >= 4.0b1',
         'ZODB >= 5.1.1',
         'ZEO',
+        'waitress >= 1.1.1',
     ],
     extras_require={
         'test': [
@@ -50,5 +51,13 @@ setup(
         ],
     },
     zip_safe=False,
-    entry_points={'zc.buildout': ['default = %s.recipe:Recipe' % name]},
+    entry_points={
+        'zc.buildout': ['default = %s.recipe:Recipe' % name],
+        'paste.server_runner': [
+            'main=plone.recipe.zope2instance.ctl:serve_paste',
+        ],
+        'paste.server_factory': [
+            'main=plone.recipe.zope2instance.ctl:server_factory',
+        ],
+        },
 )

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -27,10 +27,9 @@ typed interactively is started. Use the action "help" to find out about
 available actions.
 """
 
-from waitress.wasyncore import dispatcher
 from pkg_resources import iter_entry_points
 from time import sleep
-from waitress import serve
+from waitress.wasyncore import dispatcher
 from ZConfig.loader import SchemaLoader
 from zdaemon.zdctl import ZDCmd, ZDCtlOptions
 from zdaemon.zdoptions import ZDOptions
@@ -43,6 +42,7 @@ import six
 import socket
 import sys
 import xml.sax
+import waitress
 import zdaemon
 
 
@@ -891,7 +891,7 @@ def serve_paste(app, global_conf, **kw):
             sock = _sock
         kw.update(sockets=[sock])
     try:
-        serve(app, **kw)
+        waitress.serve(app, **kw)
     finally:
         if isinstance(sock, socket.socket):
             sock.close()

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -880,8 +880,13 @@ console -- Run the program in the console.
 def serve_paste(app, global_conf, **kw):
     sock = None
     if 'prebound' in global_conf:
-        sock = socket.fromfd(
+        _sock = socket.fromfd(
             int(global_conf['prebound']), socket.AF_INET, socket.SOCK_STREAM)
+        if six.PY2:
+            sock = socket.socket()
+            sock._sock = _sock
+        else:
+            sock = _sock
         kw.update(sockets=[sock])
     try:
         serve(app, **kw)

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -27,7 +27,7 @@ typed interactively is started. Use the action "help" to find out about
 available actions.
 """
 
-from asyncore import dispatcher
+from waitress.wasyncore import dispatcher
 from pkg_resources import iter_entry_points
 from time import sleep
 from waitress import serve

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -27,7 +27,9 @@ typed interactively is started. Use the action "help" to find out about
 available actions.
 """
 
+from asyncore import dispatcher
 from pkg_resources import iter_entry_points
+from time import sleep
 from waitress import serve
 from ZConfig.loader import SchemaLoader
 from zdaemon.zdctl import ZDCmd, ZDCtlOptions
@@ -898,8 +900,6 @@ def serve_paste(app, global_conf, **kw):
 
 def server_factory(global_conf, **kws):
     if 'fast-listen' in kws:
-        from asyncore import dispatcher
-        from time import sleep
         host, port = kws['fast-listen'].split(':')
         prebound = dispatcher()
         prebound.create_socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -909,8 +909,8 @@ def server_factory(global_conf, **kws):
             sleep(1)
         global_conf.update(prebound=str(prebound.socket.fileno()))
         del kws['fast-listen']
-
     del kws['paste.server_factory']
+
     def serve(app):
         return serve_paste(app, global_conf, **kws)
     return serve

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -659,12 +659,14 @@ class Recipe(Scripts):
         options = self.options
         wsgi_ini_path = os.path.join(options['location'], 'etc', 'wsgi.ini')
         listen = options.get('http-address', '0.0.0.0:8080')
+        fast = 'fast-' if options.get('http-fast-listen') is not None else ''
         if ':' not in listen:
             listen = '0.0.0.0:{}'.format(listen)
         options = {
             'location': options['location'],
             'http_address': listen,
             'threads': options.get('threads', 4),
+            'fast-listen': fast,
         }
         wsgi_ini = wsgi_ini_template % options
         with open(wsgi_ini_path, 'w') as f:
@@ -1189,8 +1191,9 @@ additional_zcml_template = """\
 
 wsgi_ini_template = """\
 [server:main]
-use = egg:waitress#main
-listen = %(http_address)s
+paste.server_factory = plone.recipe.zope2instance:main
+use = egg:plone.recipe.zope2instance#main
+%(fast-listen)slisten = %(http_address)s
 threads = %(threads)s
 
 [app:zope]

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -75,7 +75,8 @@ The buildout has also created an INI file containing the waitress configuration:
     >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
     >>> print(wsgi_ini)
     [server:main]
-    use = egg:waitress#main
+    paste.server_factory = plone.recipe.zope2instance:main
+    use = egg:plone.recipe.zope2instance#main
     listen = 0.0.0.0:8080
     threads = 4
     <BLANKLINE>
@@ -132,6 +133,7 @@ Let's create another buildout configuring a custom port and a custom number of w
     ... eggs =
     ... user = me:me
     ... http-address = localhost:6543
+    ... http-fast-listen = on
     ... threads = 3
     ... ''' % options)
 
@@ -149,8 +151,9 @@ The buildout has updated our INI file:
     >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
     >>> print(wsgi_ini)
     [server:main]
-    use = egg:waitress#main
-    listen = localhost:6543
+    paste.server_factory = plone.recipe.zope2instance:main
+    use = egg:plone.recipe.zope2instance#main
+    fast-listen = localhost:6543
     threads = 3
     <BLANKLINE>
     [app:zope]

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -222,7 +222,8 @@ The buildout has updated our INI file:
     >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
     >>> print(wsgi_ini)
     [server:main]
-    use = egg:waitress#main
+    paste.server_factory = plone.recipe.zope2instance:main
+    use = egg:plone.recipe.zope2instance#main
     ...
     [logger_root]
     level = ERROR
@@ -286,7 +287,8 @@ The buildout has updated our INI file:
     >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
     >>> print(wsgi_ini)
     [server:main]
-    use = egg:waitress#main
+    paste.server_factory = plone.recipe.zope2instance:main
+    use = egg:plone.recipe.zope2instance#main
     ...
     [pipeline:main]
     pipeline =
@@ -324,7 +326,8 @@ The buildout has updated our INI file:
     >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
     >>> print(wsgi_ini)
     [server:main]
-    use = egg:waitress#main
+    paste.server_factory = plone.recipe.zope2instance:main
+    use = egg:plone.recipe.zope2instance#main
     ...
     [pipeline:main]
     pipeline =


### PR DESCRIPTION
s. https://github.com/plone/plone.recipe.zope2instance/issues/71 (and also https://github.com/zopefoundation/Zope/issues/416).

waitress.serve() accepts a list of (prebound) sockets, https://waitress.readthedocs.io/en/latest/arguments.html.

Suggestion is to bind a socket before loading the application and to use a custom server_factory to make this work with PasteDeploy. This could also be done in https://github.com/zopefoundation/Zope, but plone.recipe.zope2instance is already relying on waitress anyway (Zope doesn't really seem to depend on waitress even though it is currently required it in it's setup.py).

