### PR TITLE
Restore file based logging for waitress

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,6 @@ Breaking changes:
 
 Bug fixes:
 
-
 - log level for Plone WSGI logger changed to INFO making the logging less
   verbose [ajung] (#66)
 - Improve debugging of run scripts by providing the source code for the

--- a/README.rst
+++ b/README.rst
@@ -224,12 +224,11 @@ log levels or configure `mailinglogger`.
 event-log
   The filename of the event log. Defaults to ${buildout:directory}/var/log/${partname}.log
   Setting this value to 'disable' will make the <eventlog> section to be omitted,
-  disabling logging events by default to a .log file. Used for ZServer only, not WSGI.
+  disabling logging events by default to a .log file.
 
 event-log-level
   Set the level of the console output for the event log. Level may be any of
   CRITICAL, ERROR, WARN, INFO, DEBUG, or ALL. Defaults to INFO.
-  Used for ZServer only, not WSGI.
 
 event-log-max-size
   Maximum size of event log file. Enables log rotation.
@@ -258,14 +257,15 @@ mailinglogger
 
   You will need to add `mailinglogger` to your buildout's egg section to make this work.
 
-z2-log
-  The filename for the Z2 access log. Defaults to var/log/${partname}-Z2.log.
+access-log, z2-log
+  The filename for the Z2 access log. Defaults to var/log/${partname}-Z2.log
+  (var/log/${partname}-access.log) for WSGI).
   Setting this value to 'disable' will make the <logger access> section to be omitted,
-  disabling logging access events to a .log file. Used for ZServer only, not WSGI.
+  disabling logging access events to a .log file.
 
-z2-log-level
+access-log-level, z2-log-level
   Set the log level for the access log. Level may be any of CRITICAL, ERROR,
-  WARN, INFO, DEBUG, or ALL. Defaults to WARN. Used for ZServer only, not WSGI.
+  WARN, INFO, DEBUG, or ALL. Defaults to WARN (INFO for WSGI).
 
 access-log-max-size
   Maximum size of access log file. Enables log rotation.

--- a/news/76.bugfix
+++ b/news/76.bugfix
@@ -1,0 +1,2 @@
+Restore log files for waitress.
+[tschorr]

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Zope >= 4.0b1',
         'ZODB >= 5.1.1',
         'ZEO',
+        'Paste',
     ],
     extras_require={
         'test': [

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -1293,5 +1293,5 @@ level = NOTSET
 formatter = generic
 
 [formatter_generic]
-format = %%(asctime)s %%(levelname)-5.5s [%%(name)s:%%(lineno)s][%%(threadName)s] %%(message)s
+format = %%(asctime)s %%(levelname)-7.7s [%%(name)s:%%(lineno)s][%%(threadName)s] %%(message)s
 """  # noqa: E501

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -141,7 +141,7 @@ The buildout has also created an INI file containing the waitress configuration:
     formatter = generic
     <BLANKLINE>
     [formatter_generic]
-    format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
+    format = %(asctime)s %(levelname)-7.7s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
 
 Custom WSGI options
 ==================

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -130,13 +130,13 @@ The buildout has also created an INI file containing the waitress configuration:
     <BLANKLINE>
     [handler_accesslog]
     class = FileHandler
-    args = ('.../sample-buildout/var/log/access.log','a')
+    args = ('.../sample-buildout/var/log/instance-access.log','a')
     level = INFO
     formatter = generic
     <BLANKLINE>
     [handler_eventlog]
     class = FileHandler
-    args = ('.../sample-buildout/var/log/event.log', 'a')
+    args = ('.../sample-buildout/var/log/instance.log', 'a')
     level = NOTSET
     formatter = generic
     <BLANKLINE>
@@ -198,25 +198,58 @@ Let's create a buildout:
     ... [instance]
     ... recipe = plone.recipe.zope2instance
     ... eggs =
+    ... user = me:me
     ... access-log = var/log/foo.log
     ... event-log = var/log/bar.log
+    ... z2-log-level = DEBUG
+    ... event-log-level = ERROR
     ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '.../sample-buildout/bin/instance'.
+    ...
 
 The buildout has updated our INI file:
 
     >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
     >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
     >>> print(wsgi_ini)
+    [server:main]
+    use = egg:waitress#main
+    ...
+    [logger_root]
+    level = ERROR
+    handlers = console, eventlog
+    <BLANKLINE>
+    [logger_plone]
+    level = ERROR
+    handlers = eventlog
+    qualname = plone
+    <BLANKLINE>
+    [logger_waitress]
+    level = ERROR
+    handlers = eventlog
+    qualname = waitress
+    <BLANKLINE>
+    [logger_wsgi]
+    level = DEBUG
+    handlers = accesslog
+    qualname = wsgi
+    propagate = 0
     ...
     [handler_accesslog]
     class = FileHandler
-    args = ('.../sample-buildout/var/log/foo.log','a')
-    level = INFO
+    args = ('var/log/foo.log','a')
+    level = DEBUG
     formatter = generic
     <BLANKLINE>
     [handler_eventlog]
     class = FileHandler
-    args = ('.../sample-buildout/var/log/bar.log', 'a')
+    args = ('var/log/bar.log', 'a')
     level = NOTSET
     formatter = generic
     ...
@@ -232,20 +265,30 @@ Next we want to disable access logging (but keep an event log file):
     ... [instance]
     ... recipe = plone.recipe.zope2instance
     ... eggs =
+    ... user = me:me
     ... access-log = disable
     ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '.../sample-buildout/bin/instance'.
+    ...
 
 The buildout has updated our INI file:
 
     >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
     >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
     >>> print(wsgi_ini)
+    [server:main]
+    use = egg:waitress#main
     ...
     [pipeline:main]
     pipeline =
         egg:Zope#httpexceptions
         zope
-    <BLANKLINE>
     ...
 
 Now we also want to disable event logging:
@@ -259,21 +302,31 @@ Now we also want to disable event logging:
     ... [instance]
     ... recipe = plone.recipe.zope2instance
     ... eggs =
+    ... user = me:me
     ... access-log = disable
     ... event-log = disable
     ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '.../sample-buildout/bin/instance'.
+    ...
 
 The buildout has updated our INI file:
 
     >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
     >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
     >>> print(wsgi_ini)
+    [server:main]
+    use = egg:waitress#main
     ...
     [pipeline:main]
     pipeline =
         egg:Zope#httpexceptions
         zope
-    <BLANKLINE>
     ...
     [logger_root]
     level = INFO

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -83,28 +83,44 @@ The buildout has also created an INI file containing the waitress configuration:
     use = egg:Zope#main
     zope_conf = .../sample-buildout/parts/instance/etc/zope.conf
     <BLANKLINE>
+    [filter:translogger]
+    use = egg:Paste#translogger
+    setup_console_handler = False
+    <BLANKLINE>
     [pipeline:main]
     pipeline =
+        translogger
         egg:Zope#httpexceptions
         zope
     <BLANKLINE>
     [loggers]
-    keys = root, plone
+    keys = root, plone, waitress, wsgi
     <BLANKLINE>
     [handlers]
-    keys = console
+    keys = console, accesslog, eventlog
     <BLANKLINE>
     [formatters]
     keys = generic
     <BLANKLINE>
     [logger_root]
     level = INFO
-    handlers = console
+    handlers = console, eventlog
     <BLANKLINE>
     [logger_plone]
     level = INFO
-    handlers =
+    handlers = eventlog
     qualname = plone
+    <BLANKLINE>
+    [logger_waitress]
+    level = INFO
+    handlers = eventlog
+    qualname = waitress
+    <BLANKLINE>
+    [logger_wsgi]
+    level = INFO
+    handlers = accesslog
+    qualname = wsgi
+    propagate = 0
     <BLANKLINE>
     [handler_console]
     class = StreamHandler
@@ -112,12 +128,23 @@ The buildout has also created an INI file containing the waitress configuration:
     level = NOTSET
     formatter = generic
     <BLANKLINE>
+    [handler_accesslog]
+    class = FileHandler
+    args = ('.../sample-buildout/var/log/access.log','a')
+    level = INFO
+    formatter = generic
+    <BLANKLINE>
+    [handler_eventlog]
+    class = FileHandler
+    args = ('.../sample-buildout/var/log/event.log', 'a')
+    level = NOTSET
+    formatter = generic
+    <BLANKLINE>
     [formatter_generic]
     format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
-    <BLANKLINE>
 
 Custom WSGI options
-=================
+==================
 
 Let's create another buildout configuring a custom port and a custom number of workers::
 
@@ -154,4 +181,111 @@ The buildout has updated our INI file:
     threads = 3
     <BLANKLINE>
     [app:zope]
+    ...
+
+Custom logging
+==============
+
+We want file based logging, i.e. event.log and access.log (ZServers Z2.log).
+Let's create a buildout:
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... access-log = var/log/foo.log
+    ... event-log = var/log/bar.log
+    ... ''' % options)
+
+The buildout has updated our INI file:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
+    >>> print(wsgi_ini)
+    ...
+    [handler_accesslog]
+    class = FileHandler
+    args = ('.../sample-buildout/var/log/foo.log','a')
+    level = INFO
+    formatter = generic
+    <BLANKLINE>
+    [handler_eventlog]
+    class = FileHandler
+    args = ('.../sample-buildout/var/log/bar.log', 'a')
+    level = NOTSET
+    formatter = generic
+    ...
+
+Next we want to disable access logging (but keep an event log file):
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... access-log = disable
+    ... ''' % options)
+
+The buildout has updated our INI file:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
+    >>> print(wsgi_ini)
+    ...
+    [pipeline:main]
+    pipeline =
+        egg:Zope#httpexceptions
+        zope
+    <BLANKLINE>
+    ...
+
+Now we also want to disable event logging:
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... access-log = disable
+    ... event-log = disable
+    ... ''' % options)
+
+The buildout has updated our INI file:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
+    >>> print(wsgi_ini)
+    ...
+    [pipeline:main]
+    pipeline =
+        egg:Zope#httpexceptions
+        zope
+    <BLANKLINE>
+    ...
+    [logger_root]
+    level = INFO
+    handlers = console
+    <BLANKLINE>
+    [logger_plone]
+    level = INFO
+    handlers =
+    qualname = plone
+    <BLANKLINE>
+    [logger_waitress]
+    level = INFO
+    handlers =
+    qualname = waitress
     ...


### PR DESCRIPTION
The WSGI setup currently doesn't write any logfiles (it logs to the console only). This PR tries to restore at least basic logging options for access and event log.