### PR TITLE
Fix zdaemon socket location

### DIFF
--- a/news/79.bugfix
+++ b/news/79.bugfix
@@ -1,0 +1,1 @@
+- Fix zdaemon socket location when it's not passed on the command line (`#79 <https://github.com/plone/plone.recipe.zope2instance/pull/79>`_). [tschorr]

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -100,6 +100,8 @@ class ZopeCtlOptions(ZDCtlOptions):
 
     def realize(self, *args, **kw):
         self.ZopeOptions.realize(self, *args, **kw)
+        if '-s' not in args:
+            self.sockname = None
         # Additional checking of user option; set uid and gid
         if self.user is not None:
             import pwd

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -100,8 +100,6 @@ class ZopeCtlOptions(ZDCtlOptions):
 
     def realize(self, *args, **kw):
         self.ZopeOptions.realize(self, *args, **kw)
-        if '-s' not in args:
-            self.sockname = None
         # Additional checking of user option; set uid and gid
         if self.user is not None:
             import pwd
@@ -132,8 +130,10 @@ class ZopeCtlOptions(ZDCtlOptions):
             self.program = config.runner.program
         else:
             self.program = [os.path.join(self.directory, "bin", "runzope")]
-        if self.sockname:
+        if '-s' in args:
             # set by command line option
+            # or by zdaemon.zdoptions - we need
+            # to override the latter case
             pass
         elif config.runner and config.runner.socket_name:
             self.sockname = config.runner.socket_name


### PR DESCRIPTION
`zdaemon` sets a default name 'zdsock', which is respected by `ctl.py` (instead of using it's own per instance default). As a result, you cannot start two instances/ZEO clients from the same directory because they both try to use the `zdsock` in cwd.

This PR restores the `ctl.py` default (`zopectlsock` in `clienthome`).