### PR TITLE
Add the ability to specify a custom WSGI configuration file

### DIFF
--- a/news/90.feature
+++ b/news/90.feature
@@ -1,0 +1,1 @@
+Add the ability to specify a custom WSGI configuration file

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -922,14 +922,14 @@ def main(args=None):
     """Customized entry point for launching Zope without forking other processes
     """
 
-    if '--wsgi' in args:
+    if '--wsgi' in args or '-w' in args:
         options = WSGICtlOptions()
     else:
         options = ZServerCtlOptions()
     options.add(name="no_request", short="R", long="no-request", flag=1)
     options.add(name="no_login", short="L", long="no-login", flag=1)
     options.add(name="object_path", short="O:", long="object-path=")
-    options.add(name="wsgi", short='w', long='wsgi', flag=1)
+    options.add(name="wsgi", short='w:', long='wsgi=')
     # Realize arguments and set documentation which is used in the -h option
     options.realize(args, doc=__doc__)
 
@@ -937,7 +937,7 @@ def main(args=None):
     options.interpreter = os.path.join(options.directory, 'bin', 'interpreter')
     if sys.platform == 'win32':
         options.interpreter += '-script.py'
-    if six.PY2 and not options.wsgi:
+    if six.PY2 and (options.wsgi or '').lower() in ('off', 'false', '0'):
         # only use zserver in Python 2 and if wsgi is disabled
         from ZServer.Zope2.Startup import run
         script = os.path.join(os.path.dirname(run.__file__), 'run.py')
@@ -949,9 +949,8 @@ def main(args=None):
         # wsgi is the default
         from Zope2.Startup import serve
         script = os.path.join(os.path.dirname(serve.__file__), 'serve.py')
-        wsgi_ini = os.path.join(options.directory, 'etc', 'wsgi.ini')
         options.program = [
-            options.python, options.interpreter, script, wsgi_ini
+            options.python, options.interpreter, script, options.wsgi
         ]
 
     c = ZopeCmd(options)

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -110,8 +110,12 @@ class Recipe(Scripts):
         ) not in ('off', 'disable', 'false')
 
         self.wsgi = True
-        if six.PY2 and options.get('wsgi') in ('off', 'false'):
+        self.wsgi_config = os.path.join(options['location'], 'etc', 'wsgi.ini')
+        wsgi_opt = options.get('wsgi', 'on')
+        if six.PY2 and wsgi_opt.lower() in ('off', 'false', '0'):
             self.wsgi = False
+        elif wsgi_opt.lower() not in ('on', 'true', '1'):
+            self.wsgi_config = wsgi_opt
 
         # Get Scripts' attributes
         return Scripts.__init__(self, buildout, name, options)
@@ -754,8 +758,8 @@ class Recipe(Scripts):
         arguments = ["-C", zope_conf_path, '-p', program_path]
         if zopectl_umask:
             arguments.extend(["--umask", int(zopectl_umask, 8)])
-        if self.wsgi:
-            arguments.append("--wsgi")
+        if self.wsgi and self.wsgi_config:
+            arguments.extend(['-w', self.wsgi_config])
         script_arguments = ('\n        ' + repr(arguments) +
                             '\n        + sys.argv[1:]')
 

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -1464,7 +1464,7 @@ We should have a zope instance script with the custom config file::
     >>> if WINDOWS:
     ...     instance_path += '-script.py'
     >>> open(instance_path).read()
-    "...plone.recipe.zope2instance.ctl.main(...['-C', '/some/path/my.conf', '-p', '.../bin/interpreter', '--wsgi']..."
+    "...plone.recipe.zope2instance.ctl.main(...['-C', '/some/path/my.conf', '-p', '.../bin/interpreter', '-w', '...etc/wsgi.ini']..."
 
 Custom Zope Conf Imports
 ========================
@@ -1505,6 +1505,41 @@ We should have a zope instance, with custom imports::
     %define INSTANCEHOME .../sample-buildout/parts/instance
     ...
     <BLANKLINE>
+
+Custom WSGI configuration
+=========================
+
+`wsgi` is an option that allows you to use a specific WSGI config file.
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... wsgi = /some/path/service.ini
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '...instance'.
+    Generated interpreter '.../parts/instance/bin/interpreter'...
+
+We should have a zope instance script with the custom config file::
+
+    >>> instance_path = join('bin', 'instance')
+    >>> if WINDOWS:
+    ...     instance_path += '-script.py'
+    >>> open(instance_path).read()
+    "...plone.recipe.zope2instance.ctl.main(...['-C', '/some/path/my.conf', '-p', '.../bin/interpreter', '-w', '/some/path/service.ini']..."
+
 
 Resources directory
 ===================

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -1538,7 +1538,7 @@ We should have a zope instance script with the custom config file::
     >>> if WINDOWS:
     ...     instance_path += '-script.py'
     >>> open(instance_path).read()
-    "...plone.recipe.zope2instance.ctl.main(...['-C', '/some/path/my.conf', '-p', '.../bin/interpreter', '-w', '/some/path/service.ini']..."
+    "...plone.recipe.zope2instance.ctl.main(...[...'-w', '/some/path/service.ini']..."
 
 
 Resources directory


### PR DESCRIPTION
fixes #90 

The feature "overloads" the ``wsgi`` configuration key and allows you to pass something other than the normal "on/off" types of flags. If it's not recognized as such a flag the value is considered to be a path to a WSGI configuration .ini file.

Unlike the built-in `waitress` support, this requires the user to provide that configuration file himself. The recipe simply can't know other WSGI server's configuration options.

This makes it really easy to just pull the WSGI server egg into the ``eggs`` list and generate a runner that uses a different WSGI server.