### PR TITLE
Add ability to turn off `zodb-temporary-storage` to prevent Zope 4 breakage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -487,7 +487,9 @@ zodb-cache-size-bytes
 
 zodb-temporary-storage
   If given Zope's default temporary storage definition will be replaced by
-  the lines of this parameter.
+  the lines of this parameter. If set to "off" or "false", no temporary storage
+  definition will be created. This prevents startup issues for basic Zope 4
+  sites as it does not ship with the required packages by default anymore.
 
 zope-conf
   A relative or absolute path to a `zope.conf` file. If this is given, many of

--- a/news/87.bugfix
+++ b/news/87.bugfix
@@ -1,0 +1,1 @@
+Add ability to turn off ``zodb-temporary-storage`` to prevent Zope 4 breakage

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -600,8 +600,11 @@ class Recipe(Scripts):
             storage_snippet = indent(
                 options['storage-wrapper'] % storage_snippet, 4)
 
-        zodb_tmp_storage = options.get('zodb-temporary-storage',
-                                       zodb_temporary_storage_template)
+        zodb_tmp_storage = options.get('zodb-temporary-storage', 'on')
+        if zodb_tmp_storage.lower() in ('off', 'false', '0'):
+            zodb_tmp_storage = ''
+        else:
+            zodb_tmp_storage = zodb_temporary_storage_template
         template = wsgi_conf_template if self.wsgi else zope_conf_template
 
         pid_file = options.get(

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -94,6 +94,62 @@ FTP and WebDAV
 With wsgi there is no FTP and WebDAV. Use Python 2 and ``wsgi = off`` for that.
 
 
+Turning off ZODB temporary storage
+==================================
+Zope 4 does not ship with the required packages anymore, so to avoid breakage
+the creation of the ZODB temporary storage definition can be turned off:
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... zodb-temporary-storage = off
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '...instance'.
+    Generated interpreter '.../parts/instance/bin/interpreter'...
+
+The generated configuration has no temporary storage section anymore:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print(zope_conf)
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    instancehome $INSTANCEHOME
+    %define CLIENTHOME .../sample-buildout/var/instance
+    clienthome $CLIENTHOME
+    debug-mode off
+    security-policy-implementation C
+    verbose-security off
+    default-zpublisher-encoding utf-8
+    <zodb_db main>
+        # Main database
+        cache-size 30000
+        # Blob-enabled FileStorage database
+        <blobstorage>
+          blob-dir .../sample-buildout/var/blobstorage
+          # FileStorage database
+          <filestorage>
+            path .../sample-buildout/var/filestorage/Data.fs
+          </filestorage>
+        </blobstorage>
+        mount-point /
+    </zodb_db>
+    python-check-interval 1000
+
+
 DemoStorage
 ===========
 


### PR DESCRIPTION
Fixes #87 

I have changed the allowed input values for `zodb-temporary-storage` so it can be turned off explicitly by passing something like `off` or `false`. The existing semantic of "add this but leave it empty" is non-obvious and odd.

I have called this a bug because it breaks basic Zope 4 startup right now.

My original plan of trying to peek into the resolved set of requirements and find `Products.TemporaryFolder` seemed too hard in this place of the code.

I want to use this flag (and the changes from my previous PRs) in my Zope installation documentation rewrite where I am featuring `plone.recipe.zope2instance` as the most convenient way of installing and configuring Zope, so I would like to ask for a release from you when this is merged.

See https://zope.readthedocs.io/en/latest/INSTALL.html and https://zope.readthedocs.io/en/latest/operation.html for the current documentation status.