### PR TITLE
Enable socket reuse to prevent startup errors when running in foreground

### DIFF
--- a/news/86.bugfix
+++ b/news/86.bugfix
@@ -1,0 +1,1 @@
+Enable socket reuse to prevent startup errors when running in the foreground

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -905,6 +905,7 @@ def server_factory(global_conf, **kws):
         host, port = kws['fast-listen'].split(':')
         prebound = dispatcher()
         prebound.create_socket(socket.AF_INET, socket.SOCK_STREAM)
+        prebound.set_reuse_addr()
         prebound.bind((host, int(port)))
         prebound.listen(5)
         while not prebound.readable():


### PR DESCRIPTION
Fixes #86 

With this fix I cannot reproduce the startup errors due to still-existing sockets anymore in manual testing under both Python 2.7 and 3.7 

Applying socket flags inside ``ctl.serve_paste`` didn't help here, and neither did attempting to call ``shutdown`` on the socket object before the ``close`` call in the ``finally`` clause of ``serve_paste``. Applying the reuse setting through waitress' own asyncore dispatcher worked.