### PR TITLE
Add support for the new ``debug-exceptions`` flag in Zope

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,16 @@ verbose-security
   Set to `on` to turn on verbose security (and switch to the Python security
   implementation). Defaults to `off` (and the C security implementation).
 
+debug-exceptions
+  WSGI only: set to `on` to disable exception views including
+  ``standard_error_message``. Exceptions other than ``Unauthorized`` or
+  ``ConflictError`` can then travel up into the WSGI stack. Use this option
+  if you want more convenient error debugging offered by WSGI middleware
+  such as the `werkzeug debugger
+  <https://werkzeug.palletsprojects.com/en/0.15.x/debug/>`_. See the `Zope
+  WSGI documentation <https://zope.readthedocs.io/en/latest/wsgi.html>`_ for
+  examples.
+
 Direct storage
 --------------
 

--- a/news/100.feature
+++ b/news/100.feature
@@ -1,0 +1,1 @@
+Add support for the new ``debug-exceptions`` flag in Zope

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -212,6 +212,9 @@ class Recipe(Scripts):
             module_paths = [os.path.abspath(p) for p in module_paths]
         paths_lines = '\n'.join(['path %s' % p for p in module_paths])
         debug_mode = options.get('debug-mode', 'off')
+        debug_exceptions = options.get('debug-exceptions', '')
+        if debug_exceptions:
+            debug_exceptions = debug_exceptions_template % debug_exceptions
         security_implementation = 'C'
         verbose_security = options.get('verbose-security', 'off')
         if verbose_security == 'on':
@@ -628,6 +631,7 @@ class Recipe(Scripts):
             paths_lines=paths_lines,
             products_lines=products_lines,
             debug_mode=debug_mode,
+            debug_exceptions=debug_exceptions,
             security_implementation=security_implementation,
             verbose_security=verbose_security,
             effective_user=effective_user,
@@ -1054,6 +1058,10 @@ zodb_temporary_storage_template = """
 </zodb_db>
 """.strip()
 
+debug_exceptions_template = """\
+debug-exceptions %s
+"""
+
 http_force_connection_close_template = """\
   force-connection-close %s
 """.rstrip()
@@ -1173,6 +1181,7 @@ instancehome $INSTANCEHOME
 clienthome $CLIENTHOME
 %(products_lines)s
 debug-mode %(debug_mode)s
+%(debug_exceptions)s
 security-policy-implementation %(security_implementation)s
 verbose-security %(verbose_security)s
 %(default_zpublisher_encoding)s

--- a/src/plone/recipe/zope2instance/tests/test_wsgischema.py
+++ b/src/plone/recipe/zope2instance/tests/test_wsgischema.py
@@ -111,6 +111,19 @@ class StartupTestCase(unittest.TestCase):
             """)
         self.assertEqual(conf.max_conflict_retries, 15)
 
+    def test_debug_exceptions_default(self):
+        conf, handler = self.load_config_text("""\
+        instancehome <<INSTANCE_HOME>>
+        """)
+        self.assertFalse(conf.debug_exceptions)
+
+    def test_debug_exceptions_explicit(self):
+        conf, handler = self.load_config_text("""\
+        instancehome <<INSTANCE_HOME>>
+        debug-exceptions on
+        """)
+        self.assertTrue(conf.debug_exceptions)
+
     def test_default_zpublisher_encoding(self):
         conf, dummy = self.load_config_text("""\
             instancehome <<INSTANCE_HOME>>

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -1715,3 +1715,41 @@ script::
     >>> "print('Initialization complete!')" in instance
     True
 
+
+Exceptions debug mode
+=====================
+`debug-exceptions` disables exception views including
+``standard_error_message`` and acts as a debugging aid during development.
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... debug-exceptions = on
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '...instance'.
+    Generated interpreter '.../parts/instance/bin/interpreter'...
+
+Now zope.conf should include the debug-exceptions configuration:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> zope_conf = open(os.path.join(instance, 'etc', 'zope.conf')).read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print(zope_conf)
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    ...
+    debug-exceptions on
+    ...
+    <BLANKLINE>

--- a/src/plone/recipe/zope2instance/wsgischema.xml
+++ b/src/plone/recipe/zope2instance/wsgischema.xml
@@ -276,6 +276,22 @@
     <metadefault>off</metadefault>
   </key>
 
+  <key name="debug-exceptions" datatype="boolean" default="off">
+    <description>
+    This switch controls how exceptions are handled. If it is set to
+    "off" (the default), Zope's own exception handling is active.
+    Exception views or a standard_error_message are used to handle them.
+
+    If set to "on", exceptions are not handled by Zope and can propagate
+    into the WSGI pipeline, where they may be handled by debugging
+    middleware.
+
+    This setting should always be "off" in production. It is useful for
+    developers and while debugging site issues.
+    </description>
+    <metadefault>off</metadefault>
+  </key>
+
   <key name="locale" datatype="locale" handler="locale">
     <description>
      Locale name to be used. See your operating system documentation for locale

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ skip_missing_interpreters = False
 
 [testenv]
 usedevelop = true
+install_command = python -m pip install --no-use-pep517 {opts} {packages}
 commands =
     coverage run {envbindir}/zope-testrunner --test-path=src []
 extras = test


### PR DESCRIPTION
Fixes #100 

I managed to get the tests to run after moving that `pyproject.toml` file to the side.