### PR TITLE
Try to look up a suitable log file for the ``logtail`` verb

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,8 +3,12 @@ index = https://pypi.python.org/simple/
 extends = https://zopefoundation.github.io/Zope/releases/master/versions-prod.cfg
 versions = versions
 develop = .
-parts = test
+parts = test tox
 
 [test]
 recipe = zc.recipe.testrunner
 eggs = plone.recipe.zope2instance
+
+[tox]
+recipe = zc.recipe.egg
+eggs = tox

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,12 +3,8 @@ index = https://pypi.python.org/simple/
 extends = https://zopefoundation.github.io/Zope/releases/master/versions-prod.cfg
 versions = versions
 develop = .
-parts = test tox
+parts = test
 
 [test]
 recipe = zc.recipe.testrunner
 eggs = plone.recipe.zope2instance
-
-[tox]
-recipe = zc.recipe.egg
-eggs = tox

--- a/news/85.bugfix
+++ b/news/85.bugfix
@@ -1,0 +1,1 @@
+Try to look up a suitable log file for the ``logtail`` verb

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -35,6 +35,7 @@ from zdaemon.zdctl import ZDCmd, ZDCtlOptions
 from zdaemon.zdoptions import ZDOptions
 from Zope2.Startup.options import ConditionalSchemaParser
 import csv
+import logging
 import os
 import os.path
 import pkg_resources
@@ -958,6 +959,23 @@ def main(args=None):
         options.program = [
             options.python, options.interpreter, script, options.wsgi
         ]
+
+        # Try to find the log file from the WSGI configuration
+        # Requires loading the logging configuration from the WSGI config
+        try:
+            logging.config.fileConfig(options.wsgi)
+
+            # The root logger is the only one we can identify and get
+            # reliably as we cannot know what the other loggers' names are
+            root_logger = logging.getLogger()
+
+            for handler in root_logger.handlers:
+                # Try to find a FileHandler and (ab)use its file target
+                if isinstance(handler, logging.FileHandler):
+                    options.logfile = handler.baseFilename
+                    break
+        except Exception:
+            pass  # Give up
 
     c = ZopeCmd(options)
 


### PR DESCRIPTION
Fixes #85 
This is not pretty, but with logging configuration moved entirely into the logging module itself, which has a terrible API, it's not easy to find a sensible target for the ``logtail`` operation.