### PR TITLE
Fix handling of ZEO client persistent cache and storage settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -336,13 +336,15 @@ Advanced ZEO options
 
 zeo-client-cache-size
   Set the size of the ZEO client cache. Defaults to '128MB'. The ZEO cache is
-  a disk based cache shared between application threads. It's stored inside
-  the directory designated by the `TMP` environment variable.
+  a disk based cache shared between application threads. It is stored either in
+  temporary files or, in case you activate persistent cache files with the
+  option `client` (see below), in the folder designated by the `zeo-var`
+  option.
 
 zeo-client-client
   Set the persistent cache name that is used to construct the cache
-  filenames. This enabled the ZEO cache to be persisted. Persistent cache
-  files are disabled by default.
+  filenames. This enables the ZEO cache to persist across application restarts.
+  Persistent cache files are disabled by default.
 
 zeo-client-blob-cache-size
   Set the maximum size of the ZEO blob cache, in bytes.  If not set, then
@@ -363,8 +365,9 @@ zeo-storage
   Set the storage number of the ZEO storage. Defaults to '1'.
 
 zeo-var
-  Used in the ZEO storage snippets to configure the ZEO var folder.
-  Defaults to $INSTANCE_HOME/var.
+  Used in the ZEO storage snippets to configure the ZEO var folder, which
+  is used to store persistent ZEO client cache files. Defaults to the system
+  temporary folder.
 
 Advanced options
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -466,10 +466,13 @@ scripts
     eggs =
       Plone
       mr.migrator
-      zopeskel
-    scripts = zopeskel
+      my.package
+    scripts = my_package_script
 
-  In the above example, only zopeskel's scripts will be generated.
+  In the above example, only `my_package_script` will be generated. Keep in
+  mind that the egg containing the script (``my.package`` in the example) must
+  be listed explicitly in the eggs option, even if it is a dependency of an
+  already listed egg.
 
 var
   Used to configure the base directory for all things going into var.

--- a/news/29.bugfix
+++ b/news/29.bugfix
@@ -1,0 +1,1 @@
+Clarify documentation for the `scripts` option

--- a/news/30.bugfix
+++ b/news/30.bugfix
@@ -1,0 +1,1 @@
+Fix handling of ZEO client persistent cache and storage settings

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -41,6 +41,7 @@ import pkg_resources
 import six
 import socket
 import sys
+import tempfile
 import xml.sax
 import waitress
 import zdaemon
@@ -104,6 +105,13 @@ class ZopeCtlOptions(ZDCtlOptions):
                  default=1)
 
     def realize(self, *args, **kw):
+        # Before ZConfig interprets the Zope configuration, we need to make
+        # sure to put a suitable value for ZEO_TMP into the environment.
+        # This value is used for storing ZEO persistent caches in case
+        # the var option was not also specified. Otherwise it is not used
+        # and setting it does not affect anything.
+        os.environ.update({'ZEO_TMP': tempfile.gettempdir()})
+
         self.ZopeOptions.realize(self, *args, **kw)
         # Additional checking of user option; set uid and gid
         if self.user is not None:

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -505,9 +505,6 @@ class Recipe(Scripts):
                 zeo_client_drop_cache_rather_verify = (
                     'drop-cache-rather-verify %s'
                     % zeo_client_drop_cache_rather_verify)
-            zeo_var_dir = options.get('zeo-var',
-                                      os.path.join(instance_home, 'var'))
-            zeo_client_client = options.get('zeo-client-client', '')
             zeo_client_blob_cache_size = options.get(
                 'zeo-client-blob-cache-size', '')
             zeo_client_blob_cache_size_check = options.get(
@@ -518,8 +515,15 @@ class Recipe(Scripts):
                 'max-disconnect-poll', "")
             zeo_client_read_only_fallback = options.get(
                 'zeo-client-read-only-fallback', 'false')
+            zeo_client_client = options.get('zeo-client-client', '')
             if zeo_client_client:
                 zeo_client_client = 'client %s' % zeo_client_client
+                zeo_var_dir = options.get('zeo-var', '')
+                if not zeo_var_dir:
+                    zeo_var_dir = '$(ZEO_TMP)'
+                zeo_var_dir = 'var %s' % zeo_var_dir
+            else:
+                zeo_var_dir = ''
             if zeo_client_blob_cache_size:
                 zeo_client_blob_cache_size = (
                     'blob-cache-size %s' % zeo_client_blob_cache_size)
@@ -1015,9 +1019,9 @@ zeo_storage_template = """
       %(zeo_address_list)s
       storage %(zeo_storage)s
       name zeostorage
-      var %(zeo_var_dir)s
       cache-size %(zeo_client_cache_size)s
       %(zeo_authentication)s
+      %(zeo_var_dir)s
       %(zeo_client_client)s
       %(zeo_client_min_disconnect_poll)s
       %(zeo_client_max_disconnect_poll)s
@@ -1035,11 +1039,11 @@ zeo_blob_storage_template = """
       %(zeo_address_list)s
       storage %(zeo_storage)s
       name zeostorage
-      var %(zeo_var_dir)s
       cache-size %(zeo_client_cache_size)s
       %(zeo_client_blob_cache_size)s
       %(zeo_client_blob_cache_size_check)s
       %(zeo_authentication)s
+      %(zeo_var_dir)s
       %(zeo_client_client)s
       %(zeo_client_min_disconnect_poll)s
       %(zeo_client_max_disconnect_poll)s

--- a/src/plone/recipe/zope2instance/tests/zope2instance.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance.txt
@@ -827,8 +827,8 @@ We should have a zope instance, with a basic zope.conf::
             server 8100
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -860,6 +860,7 @@ specified, they should get included in that section as well.
     ... zeo-client-blob-cache-size = 5GB
     ... zeo-client-blob-cache-size-check = 50
     ... zeo-client-read-only-fallback = true
+    ... zeo-var = %(sample_buildout)s/var
     ... ''' % options)
 
 Let's run it::
@@ -888,11 +889,11 @@ We should have a zope instance, with a basic zope.conf::
             server 8100
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
             blob-cache-size 5GB
             blob-cache-size-check 50
     <BLANKLINE>
+            var .../sample-buildout/var
             client persistentcache88
             min-disconnect-poll 10
             max-disconnect-poll 20
@@ -945,8 +946,8 @@ We should have a zope instance, with a basic zope.conf::
             server 8100
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -1001,8 +1002,8 @@ We should have a zope instance, with a basic zope.conf::
           server 8100
           storage 1
           name zeostorage
-          var .../sample-buildout/parts/instance/var
           cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -1067,8 +1068,8 @@ We should have a zope instance, with a basic zope.conf::
             server 8100
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -1126,8 +1127,8 @@ We should have a zope instance, with a basic zope.conf::
             server 127.0.0.1:8101
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -1181,8 +1182,8 @@ We should have a zope instance, with a basic zope.conf::
             server 127.0.0.1:8102
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>

--- a/src/plone/recipe/zope2instance/tests/zope2instance_zserver.txt
+++ b/src/plone/recipe/zope2instance/tests/zope2instance_zserver.txt
@@ -945,8 +945,8 @@ We should have a zope instance, with a basic zope.conf::
             server 8100
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -979,6 +979,7 @@ specified, they should get included in that section as well.
     ... zeo-client-blob-cache-size = 5GB
     ... zeo-client-blob-cache-size-check = 50
     ... zeo-client-read-only-fallback = true
+    ... zeo-var = %(sample_buildout)s/var
     ... ''' % options)
 
 Let's run it::
@@ -1007,11 +1008,11 @@ We should have a zope instance, with a basic zope.conf::
             server 8100
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
             blob-cache-size 5GB
             blob-cache-size-check 50
     <BLANKLINE>
+            var .../sample-buildout/var
             client persistentcache88
             min-disconnect-poll 10
             max-disconnect-poll 20
@@ -1065,8 +1066,8 @@ We should have a zope instance, with a basic zope.conf::
             server 8100
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -1122,8 +1123,8 @@ We should have a zope instance, with a basic zope.conf::
           server 8100
           storage 1
           name zeostorage
-          var .../sample-buildout/parts/instance/var
           cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -1189,8 +1190,8 @@ We should have a zope instance, with a basic zope.conf::
             server 8100
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -1249,8 +1250,8 @@ We should have a zope instance, with a basic zope.conf::
             server 127.0.0.1:8101
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -1305,8 +1306,8 @@ We should have a zope instance, with a basic zope.conf::
             server 127.0.0.1:8102
             storage 1
             name zeostorage
-            var .../sample-buildout/parts/instance/var
             cache-size 128MB
+    <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>


### PR DESCRIPTION
Fixes #30 

The handling of ZEO client settings ``client`` and especially ``var`` and its documentation here were broken on several levels.

There appeared to be a misunderstanding of ``var``, otherwise the recipe would not have set it for all cases. ``var`` is only ever consulted in one specific case: If ``client`` is set to signal the wish for persistent ZEO cache files.

The change only ever sets ``var`` explicitly if the recipe gets both a ``zeo-client-client`` and a  ``zeo-var`` value.

For cases where ``client`` is set but ``var`` is not the ZEO ClientStorage code would use the current working directory to store the persistent cache files. That's just a bad idea all around. Instead, it will be forced to the system's temporary folder instead.

For those who wonder why ``zeo-var`` is not set to a temporary path at buildout time and instead an indirection with an environment variable is used: Some operating systems do not use one fixed location for temporary files. They create them for each logged-in user, and with a different path each time they log in. That's why the only safe way to find it is the moment the runner is executed.