### PR TITLE
Add Known Issues section to README and other fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -553,8 +553,12 @@ http-header-max-length
 
     http-header-max-length = 16384
 
-Additional Control Script `debug`, `console` and `run` Commands
-===============================================================
+
+The generated control script
+============================
+
+The `debug`, `console` and `run` commands
+-----------------------------------------
 
 The extended Zope control script installed by this recipe, usually
 `bin/instance` by convention, offers a `debug` command and another
@@ -586,8 +590,8 @@ Second, IDEs like WingIDE and PyCharm support debugging running
 processes from within. For this to work, the process should also
 not fork away.
 
-Additional control script commands
-----------------------------------
+Developing your own control script commands
+-------------------------------------------
 
 Third-party distributions may add additional commands to the control script by
 installing a 'plone.recipe.zope2instance.ctl' entry point. For example,
@@ -615,6 +619,13 @@ parameters:
     An instance of plone.recipe.zope2instance.ctl.AdjustedZopeCmd.
   args
     Any additional arguments that were passed on the command line.
+
+Known issues
+------------
+
+* the ``restart`` command will not function reliably if you run the buildout
+  while the Zope instance is still running. In those cases, always use
+  ``stop`` followed by ``start`` to restart the Zope instance.
 
 Reporting bugs or asking questions
 ==================================

--- a/README.rst
+++ b/README.rst
@@ -630,5 +630,6 @@ Known issues
 Reporting bugs or asking questions
 ==================================
 
-We have a shared bugtracker and help desk on Launchpad:
-https://bugs.launchpad.net/collective.buildout/
+PLease use the bug tracker in this repository at
+https://github.com/plone/plone.recipe.zope2instance/issues for questions and
+bug reports.

--- a/README.rst
+++ b/README.rst
@@ -630,6 +630,6 @@ Known issues
 Reporting bugs or asking questions
 ==================================
 
-PLease use the bug tracker in this repository at
+Please use the bug tracker in this repository at
 https://github.com/plone/plone.recipe.zope2instance/issues for questions and
 bug reports.

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. contents::
+
+
 Introduction
 ============
 
@@ -26,10 +29,6 @@ You can use it with a part like this::
 .. ATTENTION::
    This release is targeted at Plone 5.2, ZODB 5, Zope 4, and Python 2.7, 3.6 or 3.7.
    If you are using this recipe with earlier versions, you should use one of the releases from the 4.x series.
-
-
-.. contents::
-   :local:
 
 
 Options

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,11 @@ You can use it with a part like this::
    This release is targeted at Plone 5.2, ZODB 5, Zope 4, and Python 2.7, 3.6 or 3.7.
    If you are using this recipe with earlier versions, you should use one of the releases from the 4.x series.
 
+
+.. contents::
+   :local:
+
+
 Options
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. contents::
-
-
 Introduction
 ============
 
@@ -29,6 +26,9 @@ You can use it with a part like this::
 .. ATTENTION::
    This release is targeted at Plone 5.2, ZODB 5, Zope 4, and Python 2.7, 3.6 or 3.7.
    If you are using this recipe with earlier versions, you should use one of the releases from the 4.x series.
+
+
+.. contents::
 
 
 Options
@@ -554,7 +554,7 @@ http-header-max-length
     http-header-max-length = 16384
 
 Additional Control Script `debug`, `console` and `run` Commands
----------------------------------------------------------------
+===============================================================
 
 The extended Zope control script installed by this recipe, usually
 `bin/instance` by convention, offers a `debug` command and another
@@ -617,7 +617,7 @@ parameters:
     Any additional arguments that were passed on the command line.
 
 Reporting bugs or asking questions
-----------------------------------
+==================================
 
 We have a shared bugtracker and help desk on Launchpad:
 https://bugs.launchpad.net/collective.buildout/

--- a/news/107.bugfix
+++ b/news/107.bugfix
@@ -1,0 +1,1 @@
+Document where ``restart`` can break in the project README


### PR DESCRIPTION
Fixes #107 

I added a new Known Issues section to document the `restart` behavior. I also added a table of contents because the document is too hard to navigate, and then I rearranged the structure a little bit.
