### PR TITLE
Prevent constant `waitress.queue` log messages on the console

### DIFF
--- a/news/110.bugfix
+++ b/news/110.bugfix
@@ -1,0 +1,2 @@
+Prevent constant `waitress.queue` log messages on the console and just send
+them to the event log.

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -1268,7 +1268,7 @@ pipeline =
     %(pipeline)s
 
 [loggers]
-keys = root, plone, waitress, wsgi
+keys = root, plone, waitress.queue, waitress, wsgi
 
 [handlers]
 keys = console, accesslog, eventlog
@@ -1284,6 +1284,12 @@ handlers = %(root_handlers)s
 level = %(eventlog_level)s
 handlers = %(event_handlers)s
 qualname = plone
+
+[logger_waitress.queue]
+level = INFO
+handlers = eventlog
+qualname = waitress.queue
+propagate = 0
 
 [logger_waitress]
 level = %(eventlog_level)s

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -95,7 +95,7 @@ The buildout has also created an INI file containing the waitress configuration:
         zope
     <BLANKLINE>
     [loggers]
-    keys = root, plone, waitress, wsgi
+    keys = root, plone, waitress.queue, waitress, wsgi
     <BLANKLINE>
     [handlers]
     keys = console, accesslog, eventlog
@@ -111,6 +111,12 @@ The buildout has also created an INI file containing the waitress configuration:
     level = INFO
     handlers = eventlog
     qualname = plone
+    <BLANKLINE>
+    [logger_waitress.queue]
+    level = INFO
+    handlers = eventlog
+    qualname = waitress.queue
+    propagate = 0
     <BLANKLINE>
     [logger_waitress]
     level = INFO
@@ -237,6 +243,12 @@ The buildout has updated our INI file:
     handlers = eventlog
     qualname = plone
     <BLANKLINE>
+    [logger_waitress.queue]
+    level = INFO
+    handlers = eventlog
+    qualname = waitress.queue
+    propagate = 0
+    <BLANKLINE>
     [logger_waitress]
     level = ERROR
     handlers = eventlog
@@ -345,6 +357,12 @@ The buildout has updated our INI file:
     level = INFO
     handlers =
     qualname = plone
+    <BLANKLINE>
+    [logger_waitress.queue]
+    level = INFO
+    handlers = eventlog
+    qualname = waitress.queue
+    propagate = 0
     <BLANKLINE>
     [logger_waitress]
     level = INFO


### PR DESCRIPTION
Fixes #110 

This change will prevent waitress.queue messages from appearing in the console when running the instance in the foreground. They are sent to the event log instead.
