### PR TITLE
Add support for ``zmi-bookmarkable-urls`` and ``pid-filename``

### DIFF
--- a/news/112.bugfix
+++ b/news/112.bugfix
@@ -1,0 +1,2 @@
+Fix startup issues by adding support for new Zope configuration keys
+``zmi-bookmarkable-urls`` and ``pid-filename``

--- a/src/plone/recipe/zope2instance/wsgischema.xml
+++ b/src/plone/recipe/zope2instance/wsgischema.xml
@@ -347,6 +347,26 @@
      <metadefault>on</metadefault>
   </key>
 
+  <key name="zmi-bookmarkable-urls" datatype="boolean"
+       default="on">
+     <description>
+     Set this directive to 'on' to cause Zope to show the ZMI right hand
+     frame's URL in the browser navigation bar as opposed to the static
+     '/manage'. The default is 'on'. To restore the behavior of Zope 2
+     where the URL was always static unless you opened the right-hand frame in
+     its own browser window, set this to off.
+     </description>
+     <metadefault>on</metadefault>
+  </key>
+
+  <key name="pid-filename" datatype="existing-dirpath">
+    <description>
+      The full path to which the Zope process will write its
+      OS process id at startup.
+    </description>
+    <metadefault>$clienthome/Z4.pid</metadefault>
+  </key>
+
   <multikey name="trusted-proxy" datatype="ipaddr-or-hostname"
        attribute="trusted_proxies">
      <description>


### PR DESCRIPTION
These keys have been added to Zope's own wsgischema.xml and if someone tries to use them with plone.recipe.zope2instance it will fail until this PR is merged and released.

Fixes #112.