### PR TITLE
Fix a deprecation warning. 

### DIFF
--- a/news/122.bugfix
+++ b/news/122.bugfix
@@ -1,0 +1,1 @@
+Fixed a deprecation warning when importing "makerequest" from Testing.ZopeTestCase.utils. This also fixes a side effect which can bite you if you rely on ZOPETESTCASE environment variable, which is set to "1" whenever you import something from Testing.ZopeTestCase.

--- a/news/122.bugfix
+++ b/news/122.bugfix
@@ -1,1 +1,1 @@
-Fixed a deprecation warning when importing "makerequest" from Testing.ZopeTestCase.utils. This also fixes a side effect which can bite you if you rely on ZOPETESTCASE environment variable, which is set to "1" whenever you import something from Testing.ZopeTestCase.
+Fixed a deprecation warning when importing "makerequest" from Testing.ZopeTestCase.utils. This also fixes a side effect which can bite you if you rely on ZOPETESTCASE environment variable, only being set to "1" during test runs.

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -678,8 +678,8 @@ class ZopeCmd(ZDCmd):
 
         if not self.options.no_request:
             cmdline += (
-                'from Testing.ZopeTestCase.utils import makerequest; '
-                'app = makerequest(app); '
+                'import Testing.makerequest; '
+                'app = Testing.makerequest(app); '
                 # REQUEST.traverse needs this but no reason not to set
                 # this even if we're not traversing to an object
                 'app.REQUEST[\'PARENTS\'] = [app]; '


### PR DESCRIPTION
This also fixes a side effect which can bite you if you rely on ZOPETESTCASE environment variable, which is set to "1" whenever you import something from Testing.ZopeTestCase.