### PR TITLE
Add Sentry support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,6 +318,18 @@ sentry_dsn
   `plone.recipe.zope2instance[sentry]`.
   Available for WSGI only.
 
+sentry_level
+  Set the logging level for Sentry breadcrumbs.
+  Available for WSGI only.
+
+sentry_event_level
+  Set the logging level for Sentry events.
+  Available for WSGI only.
+
+sentry_ignore
+  Set the (space separated list of) logger names that are ignored by Sentry.
+  Available for WSGI only.
+
 Load non-setuptools compatible Python libraries
 -----------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -311,6 +311,11 @@ access-log-custom
   Like `event-log-custom`, a custom section for the access logger, to be able
   to use another event logger than `logfile`. Used for ZServer only, not WSGI.
 
+sentry_dsn
+  Provide a Sentry DSN here to enable basic Sentry logging documented
+  in `<https://docs.sentry.io/platforms/python/logging/>`_.
+  Available for WSGI only.
+
 Load non-setuptools compatible Python libraries
 -----------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -313,7 +313,9 @@ access-log-custom
 
 sentry_dsn
   Provide a Sentry DSN here to enable basic Sentry logging documented
-  in `<https://docs.sentry.io/platforms/python/logging/>`_.
+  in `<https://docs.sentry.io/platforms/python/logging/>`_. You will need to add the
+  Python Sentry SDK, either by adding it to your eggs section directly or by adding
+  `plone.recipe.zope2instance[sentry]`.
   Available for WSGI only.
 
 Load non-setuptools compatible Python libraries

--- a/news/124.feature
+++ b/news/124.feature
@@ -1,0 +1,1 @@
+Add Sentry support by adding a new filter to the WSGI pipeline.

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ setup(
         'test': [
             'zope.testrunner',
         ],
+        'sentry': [
+            'sentry-sdk',
+        ]
     },
     zip_safe=False,
     entry_points={
@@ -59,6 +62,9 @@ setup(
         ],
         'paste.server_factory': [
             'main=plone.recipe.zope2instance.ctl:server_factory',
+        ],
+        'paste.filter_factory': [
+            'sentry=plone.recipe.zope2instance.sentry:sdk_init',
         ],
         },
 )

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -755,6 +755,9 @@ class Recipe(Scripts):
         sentry_dsn = options.get('sentry_dsn', '')
         if sentry_dsn:
             pipeline.append('sentry')
+        sentry_level = options.get('sentry_level', 'INFO')
+        sentry_event_level = options.get('sentry_event_level', 'ERROR')
+        sentry_ignore = options.get('sentry_ignore', '')
 
         pipeline.append('zope')
         pipeline = '\n    '.join(pipeline)
@@ -771,6 +774,9 @@ class Recipe(Scripts):
             'eventlog_level': eventlog_level,
             'accesslog_level': accesslog_level,
             'sentry_dsn': sentry_dsn,
+            'sentry_level': sentry_level,
+            'sentry_event_level': sentry_event_level,
+            'sentry_ignore': sentry_ignore,
         }
         wsgi_ini = wsgi_ini_template % options
         with open(wsgi_ini_path, 'w') as f:
@@ -1315,6 +1321,9 @@ setup_console_handler = False
 [filter:sentry]
 use = egg:plone.recipe.zope2instance#sentry
 dsn = %(sentry_dsn)s
+level = %(sentry_level)s
+event_level = %(sentry_event_level)s
+ignorelist = %(sentry_ignore)s
 
 [pipeline:main]
 pipeline =

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -743,12 +743,21 @@ class Recipe(Scripts):
             'access-log-level',
             options.get('z2-log-level', 'INFO'))
 
+        pipeline = []
         if accesslog_name.lower() == 'disable':
-            pipeline = '\n    '.join(['egg:Zope#httpexceptions', 'zope'])
+            pipeline = [
+                'egg:Zope#httpexceptions']
             event_handlers = ''
         else:
-            pipeline = '\n    '.join(
-                ['translogger', 'egg:Zope#httpexceptions', 'zope'])
+            pipeline = [
+                'translogger', 'egg:Zope#httpexceptions']
+
+        sentry_dsn = options.get('sentry_dsn', '')
+        if sentry_dsn:
+            pipeline.append('sentry')
+
+        pipeline.append('zope')
+        pipeline = '\n    '.join(pipeline)
         options = {
             'location': options['location'],
             'http_address': listen,
@@ -761,6 +770,7 @@ class Recipe(Scripts):
             'pipeline': pipeline,
             'eventlog_level': eventlog_level,
             'accesslog_level': accesslog_level,
+            'sentry_dsn': sentry_dsn,
         }
         wsgi_ini = wsgi_ini_template % options
         with open(wsgi_ini_path, 'w') as f:
@@ -1301,6 +1311,10 @@ zope_conf = %(location)s/etc/zope.conf
 [filter:translogger]
 use = egg:Paste#translogger
 setup_console_handler = False
+
+[filter:sentry]
+use = egg:plone.recipe.zope2instance#sentry
+dsn = %(sentry_dsn)s
 
 [pipeline:main]
 pipeline =

--- a/src/plone/recipe/zope2instance/sentry.py
+++ b/src/plone/recipe/zope2instance/sentry.py
@@ -1,0 +1,8 @@
+import sentry_sdk
+
+
+def sdk_init(global_conf, dsn):
+    def filter(app):
+        sentry_sdk.init(dsn=dsn)
+        return app
+    return filter

--- a/src/plone/recipe/zope2instance/sentry.py
+++ b/src/plone/recipe/zope2instance/sentry.py
@@ -1,8 +1,22 @@
+import logging
 import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 
 
-def sdk_init(global_conf, dsn):
+def sdk_init(
+        global_conf,
+        dsn,
+        level='INFO',
+        event_level='ERROR',
+        ignorelist=''):
+    sentry_logging = LoggingIntegration(
+        level=logging.__dict__[level],
+        event_level=logging.__dict__[event_level]
+    )
+    for logger in ignorelist.split():
+        ignore_logger(logger)
+
     def filter(app):
-        sentry_sdk.init(dsn=dsn)
+        sentry_sdk.init(dsn=dsn, integrations=[sentry_logging])
         return app
     return filter

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -415,6 +415,62 @@ The buildout has updated our INI file:
     [filter:sentry]
     use = egg:plone.recipe.zope2instance#sentry
     dsn = https://f00ba4ba2@my.sentry.server/9999
+    level = INFO
+    event_level = ERROR
+    ignorelist =
+    <BLANKLINE>
+    [pipeline:main]
+    pipeline =
+        translogger
+        egg:Zope#httpexceptions
+        sentry
+        zope
+    <BLANKLINE>
+    [loggers]
+    ...
+
+Let's update our buildout with some Sentry options:
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ...     plone.recipe.zope2instance[sentry]
+    ... user = me:me
+    ... sentry_dsn = https://f00ba4ba2@my.sentry.server/9999
+    ... sentry_level = DEBUG
+    ... sentry_event_level = WARNING
+    ... sentry_ignore = waitress.queue foo
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Generated script '.../sample-buildout/bin/instance'.
+    ...
+
+The buildout has updated our INI file:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
+    >>> print(wsgi_ini)
+    [server:main]
+    paste.server_factory = plone.recipe.zope2instance:main
+    use = egg:plone.recipe.zope2instance#main
+    ...
+    [filter:sentry]
+    use = egg:plone.recipe.zope2instance#sentry
+    dsn = https://f00ba4ba2@my.sentry.server/9999
+    level = DEBUG
+    event_level = WARNING
+    ignorelist = waitress.queue foo
     <BLANKLINE>
     [pipeline:main]
     pipeline =

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -90,7 +90,7 @@ The buildout has also created an INI file containing the waitress configuration:
     [filter:translogger]
     use = egg:Paste#translogger
     setup_console_handler = False
-    <BLANKLINE>
+    ...
     [pipeline:main]
     pipeline =
         translogger
@@ -371,4 +371,57 @@ The buildout has updated our INI file:
     level = INFO
     handlers =
     qualname = waitress
+    ...
+
+Sentry support
+==============
+
+We want to sent logging events to Sentry.
+Let's create a buildout:
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ...     plone.recipe.zope2instance[sentry]
+    ... user = me:me
+    ... sentry_dsn = https://f00ba4ba2@my.sentry.server/9999
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    Getting distribution for 'sentry-sdk'.
+    ...
+    Generated script '.../sample-buildout/bin/instance'.
+    ...
+
+The buildout has updated our INI file:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
+    >>> print(wsgi_ini)
+    [server:main]
+    paste.server_factory = plone.recipe.zope2instance:main
+    use = egg:plone.recipe.zope2instance#main
+    ...
+    [filter:sentry]
+    use = egg:plone.recipe.zope2instance#sentry
+    dsn = https://f00ba4ba2@my.sentry.server/9999
+    <BLANKLINE>
+    [pipeline:main]
+    pipeline =
+        translogger
+        egg:Zope#httpexceptions
+        sentry
+        zope
+    <BLANKLINE>
+    [loggers]
     ...


### PR DESCRIPTION
This PR adds basic Sentry support using the Python Sentry SDK as documented in https://docs.sentry.io/platforms/python/logging/.