### PR TITLE
Basic repoze.profile integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,7 @@ profile
   Set to ``on`` enables `repoze.profile <https://github.com/repoze/repoze.profile>`_.
   Defaults to ``off``,
   If switched on there are further options prefixed with ``profile_`` to configure it as below.
+  You will need to add the `repoze.profile` package, either by adding it to your eggs section directly or by using the extra `plone.recipe.zope2instance[profile]`.
 
 profile_log_filename
   Filename of the raw profile data.

--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ verbose-security
   implementation). Defaults to `off` (and the C security implementation).
 
 debug-exceptions
-  WSGI only: set to `on` to disable exception views including
+  WSGI only: set to ``on`` to disable exception views including
   ``standard_error_message``. Exceptions other than ``Unauthorized`` or
   ``ConflictError`` can then travel up into the WSGI stack. Use this option
   if you want more convenient error debugging offered by WSGI middleware
@@ -165,6 +165,38 @@ debug-exceptions
   <https://werkzeug.palletsprojects.com/en/0.15.x/debug/>`_. See the `Zope
   WSGI documentation <https://zope.readthedocs.io/en/latest/wsgi.html>`_ for
   examples.
+
+profile
+  Set to ``on`` enables `repoze.profile <https://github.com/repoze/repoze.profile>`_.
+  Defaults to ``off``,
+  If switched on there are further options prefixed with ``profile_`` to configure it as below.
+
+profile_log_filename
+  Filename of the raw profile data.
+  Default to ``profile-SECTIONNAME.raw``.
+  This file contains the raw profile data for further analysis.
+
+profile_cachegrind_filename
+  If the package ``pyprof2calltree`` is installed, another file is written.
+  It is meant for consumation with any cachegrind compatible application.
+  Defaults to ``cachegrind.out.SECTIONNAME``.
+
+profile_discard_first_request
+  Defaults to ``true``.
+  See `repoze.profile docs <https://repozeprofile.readthedocs.io/en/latest/#configuration-via-python>`_ for details.
+
+profile_path
+  Defaults to ``/__profile__``.
+  The path for through the web access to the last profiled request.
+
+profile_flush_at_shutdown
+  Defaults to ``true``.
+  See `repoze.profile docs <https://repozeprofile.readthedocs.io/en/latest/#configuration-via-python>`_ for details.
+
+profile_unwind
+  Defaults to ``false``.
+  See `repoze.profile docs <https://repozeprofile.readthedocs.io/en/latest/#configuration-via-python>`_ for details.
+
 
 Direct storage
 --------------

--- a/news/129.feature
+++ b/news/129.feature
@@ -1,0 +1,1 @@
+Add repoze.profile profiling middleware support [jensens]

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,8 @@ setup(
         'ZEO',
         'waitress >= 1.2.0',
         'Paste',
-<<<<<<< HEAD
         'python-dotenv'
-=======
         'repoze.profile',
->>>>>>> 8f25081... Basic repoze.profile integration
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,11 @@ setup(
         'ZEO',
         'waitress >= 1.2.0',
         'Paste',
+<<<<<<< HEAD
         'python-dotenv'
+=======
+        'repoze.profile',
+>>>>>>> 8f25081... Basic repoze.profile integration
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'ZEO',
         'waitress >= 1.2.0',
         'Paste',
-        'python-dotenv'
+        'python-dotenv',
         'repoze.profile',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'waitress >= 1.2.0',
         'Paste',
         'python-dotenv',
-        'repoze.profile',
     ],
     extras_require={
         'test': [
@@ -63,6 +62,9 @@ setup(
         ],
         'sentry': [
             'sentry-sdk',
+        ],
+        'profile': [
+            'repoze.profile',
         ]
     },
     zip_safe=False,

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -798,9 +798,13 @@ class Recipe(Scripts):
         sentry_level = options.get('sentry_level', 'INFO')
         sentry_event_level = options.get('sentry_event_level', 'ERROR')
         sentry_ignore = options.get('sentry_ignore', '')
+
         profile = options.get('profile', '').strip() == 'on'
         if profile:
-            pipeline.append('profile')
+            if "zope" in pipeline:
+                pipeline.insert(pipeline.index("zope"), 'profile')
+            else:
+                pipeline.append('profile')
         default_profile_log_filename = os.path.sep.join(
             [
                 var_dir,

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -798,6 +798,41 @@ class Recipe(Scripts):
         sentry_level = options.get('sentry_level', 'INFO')
         sentry_event_level = options.get('sentry_event_level', 'ERROR')
         sentry_ignore = options.get('sentry_ignore', '')
+        profile = options.get('profile', '').strip() == 'on'
+        if profile:
+            pipeline.append('profile')
+        default_profile_log_filename = os.path.sep.join(
+            [
+                var_dir,
+                'log',
+                'profile-{0}.raw'.format(self.name),
+            ]
+        )
+        profile_log_filename = options.get(
+            'profile_log_filename',
+            default_profile_log_filename
+        )
+        default_profile_log_filename = os.path.sep.join(
+            [
+                var_dir,
+                'log',
+                'cachegrind.out.{0}'.format(self.name),
+            ]
+        )
+        profile_cachegrind_filename = options.get(
+            'profile_cachegrind_filename',
+            default_profile_log_filename
+        )
+        profile_discard_first_request = options.get(
+            'profile_discard_first_request',
+            'true'
+        )
+        profile_path = options.get('profile_path', '/__profile__')
+        profile_flush_at_shutdown = options.get(
+            'profile_flush_at_shutdown',
+            'true'
+        )
+        profile_unwind = options.get('profile_unwind', 'false')
 
         if "zope" not in pipeline:
             pipeline.append('zope')
@@ -827,8 +862,13 @@ class Recipe(Scripts):
             'sentry_ignore': sentry_ignore,
             'sentry_level': sentry_level,
             'threads': options.get('threads', 4),
+            'profile_log_filename': profile_log_filename,
+            'profile_cachegrind_filename': profile_cachegrind_filename,
+            'profile_discard_first_request': profile_discard_first_request,
+            'profile_path': profile_path,
+            'profile_flush_at_shutdown': profile_flush_at_shutdown,
+            'profile_unwind': profile_unwind,
         }
-
         global wsgi_ini_template
         wsgi_ini_template_path = self.options.get('wsgi-ini-template')
         if wsgi_ini_template_path:
@@ -1408,6 +1448,15 @@ dsn = %(sentry_dsn)s
 level = %(sentry_level)s
 event_level = %(sentry_event_level)s
 ignorelist = %(sentry_ignore)s
+
+[filter:profile]
+use = egg:repoze.profile
+log_filename = %(profile_log_filename)s
+cachegrind_filename = %(profile_cachegrind_filename)s
+discard_first_request = %(profile_discard_first_request)s
+path = %(profile_path)s
+flush_at_shutdown = %(profile_flush_at_shutdown)s
+unwind = %(profile_unwind)s
 
 [pipeline:main]
 pipeline =

--- a/src/plone/recipe/zope2instance/tests/wsgi.rst
+++ b/src/plone/recipe/zope2instance/tests/wsgi.rst
@@ -469,7 +469,7 @@ The buildout has updated our INI file:
     level = INFO
     event_level = ERROR
     ignorelist =
-    <BLANKLINE>
+    ...
     [pipeline:main]
     pipeline =
         translogger
@@ -522,7 +522,7 @@ The buildout has updated our INI file:
     level = DEBUG
     event_level = WARNING
     ignorelist = waitress.queue foo
-    <BLANKLINE>
+    ...
     [pipeline:main]
     pipeline =
         translogger
@@ -570,6 +570,56 @@ The buildout has updated our INI file and we can see that we have a custom pipel
     pipeline =
         foo
         bar
+        zope
+    <BLANKLINE>
+    [loggers]
+    ...
+
+
+With repoze.profile middleware
+==============================
+
+The recipe can configure custom pipelines in the ``wsgi.ini``::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... profile = on
+    ... ''' % options)
+
+Let's run it::
+
+    >>> print(system(join('bin', 'buildout'))),
+    Uninstalling instance.
+    Installing instance.
+    ...
+
+The buildout has updated our INI file and we can see that we have a custom pipeline::
+
+    >>> wsgi_ini = open(os.path.join(instance, 'etc', 'wsgi.ini')).read()
+    >>> print(wsgi_ini)
+    [server:main]
+    ...
+    [filter:profile]
+    use = egg:repoze.profile
+    ...
+    discard_first_request = true
+    path = /__profile__
+    flush_at_shutdown = true
+    unwind = false
+    <BLANKLINE>
+    [pipeline:main]
+    pipeline =
+        translogger
+        egg:Zope#httpexceptions
+        profile
         zope
     <BLANKLINE>
     [loggers]


### PR DESCRIPTION
Basic integration of repoze.profile to allow easy profiling of requests in Zope4.

Todo:
- [x] manual check if profiling works
- [x] check if cachegrind output works (KCachegrind loads the fine)
- [x] check if all options are working
- [x] fix/ create tests