### PR TITLE
New zope options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,10 @@ dist
 eggs
 include/
 lib/
+lib64
 parts
 pip-selfcheck.json
+pyvenv.cfg
 /.coverage
 /.installed.cfg
 /.tox

--- a/news/134.feature
+++ b/news/134.feature
@@ -1,0 +1,1 @@
+support for Zope options `webdav-source-port` and `enable-ms-public-header`

--- a/src/plone/recipe/zope2instance/wsgischema.xml
+++ b/src/plone/recipe/zope2instance/wsgischema.xml
@@ -500,4 +500,46 @@
     </description>
   </key>
 
+  <key name="webdav-source-port" datatype="integer" default="0">
+    <description>
+      This value designates a network port number as WebDAV source port.
+
+      WebDAV requires special handling for GET requests. A WebDAV
+      client expects to receive the un-rendered source in the returned
+      response body, not the rendered result a web browser would get.
+
+      If this value is set to a positive integer, any GET request coming into
+      Zope via the designated port will be marked up to signal that this is a
+      WebDAV request. This request markup resembles what ZServer did for
+      requests coming though its designated WebDAV source server port, so it is
+      backwards-compatible for existing code that offers WebDAV handling under
+      ZServer.
+
+      Please note that Zope itself has no server capabilities and cannot open
+      network ports. You need to configure your WSGI server to listen on the
+      designated port.
+    </description>
+  </key>
+
+  <key name="enable-ms-public-header"
+       datatype="boolean"
+       handler="enable_ms_public_header"
+       default="off">
+   <description>
+    Set this directive to 'on' to enable sending the "Public" header
+    in response to an WebDAV OPTIONS request - but only those coming from
+    Microsoft WebDAV clients.
+
+    Though recent WebDAV drafts mention this header, the original
+    WebDAV RFC did not mention it as part of the standard. Very few
+    web servers out there include this header in their replies, most
+    notably IIS and Netscape Enterprise 3.6.
+
+    Documentation about this header is sparse. Some versions of
+    Microsoft Web Folders after 2005 apparently require its presence,
+    but most documentation links have expired.
+   </description>
+   <metadefault>off</metadefault>
+  </key>
+
 </schema>


### PR DESCRIPTION
Fixes #134 

This PR adds minimal support for two new Zope options. For now it is OK to just have them in the schema so that these options can be put into `zope-conf-additional` and sites running on `plone.recipe.zope2instance` don't completely fail when you try starting them with these options.

The fact that a separate copy of the schema is maintained here is a real PIA. I wonder if there's a better way, like `plone.recipe.zope2instance` using Zope's copy during startup instead.