### PR TITLE
Generate raw strings in order to allow windows backslashes in paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -361,7 +361,7 @@ access-log-args
   `("access.log", )` The `access-log-args` is used to specify the positional
   parameters for the logging handler configured through `access-log-handler`.
 
-  Default: `("access.log", "a")`
+  Default: `(r"access.log", "a")`
 
 access-log-kwargs
   A python dictionary used for passing keyword argument for the logging handler
@@ -385,7 +385,7 @@ This example uses a `RotatingFileHandler` https://docs.python.org/3/library/logg
 which rotates the access log when it becomes larger than 10 MB while keeping seven copies::
 
     access-log-handler = logging.handlers.RotatingFileHandler
-    access-log-args  = ("access.log", "a")
+    access-log-args  = (r"access.log", "a")
     access-log-kwargs = {"maxBytes": 10000000, "maxCount": 7}
 
 Example (rotating of event log after each day)
@@ -395,7 +395,7 @@ This example uses a `TimedRotatingFileHandler` https://docs.python.org/3/library
 for rotating the event log every 24 hours or one day::
 
     event-log-handler = logging.handlers.TimedRotatingFileHandler
-    event-log-args = ("event.log", )
+    event-log-args = (r"event.log", )
     event-log-kwargs = {"when": "D", "interval": 1}
 
 Load non-setuptools compatible Python libraries

--- a/news/145.bugfix
+++ b/news/145.bugfix
@@ -1,0 +1,2 @@
+Fix "SyntaxError" on windows: Generate raw strings in order to allow backslashes in log file paths.
+[jensens]

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -743,7 +743,7 @@ class Recipe(Scripts):
         eventlog_kwargs = options.get('event-log-kwargs', '{}')
         eventlog_args = options.get('event-log-args')
         if not eventlog_args:
-            eventlog_args = "('{}', 'a')".format(eventlog_name)
+            eventlog_args = "(r'{}', 'a')".format(eventlog_name)
         else:
             eventlog_args = eventlog_args.format(eventlog_name)
 
@@ -767,7 +767,7 @@ class Recipe(Scripts):
         accesslog_kwargs = options.get('access-log-kwargs', '{}')
         accesslog_args = options.get('access-log-args')
         if not accesslog_args:
-            accesslog_args = "('{}', 'a')".format(accesslog_name)
+            accesslog_args = "(r'{}', 'a')".format(accesslog_name)
         else:
             accesslog_args = accesslog_args.format(accesslog_name)
 

--- a/src/plone/recipe/zope2instance/tests/wsgi.txt
+++ b/src/plone/recipe/zope2instance/tests/wsgi.txt
@@ -140,14 +140,14 @@ The buildout has also created an INI file containing the waitress configuration:
     <BLANKLINE>
     [handler_accesslog]
     class = FileHandler
-    args = ('.../sample-buildout/var/log/instance-access.log', 'a')
+    args = (r'.../sample-buildout/var/log/instance-access.log', 'a')
     kwargs = {}
     level = INFO
     formatter = message
     <BLANKLINE>
     [handler_eventlog]
     class = FileHandler
-    args = ('.../sample-buildout/var/log/instance.log', 'a')
+    args = (r'.../sample-buildout/var/log/instance.log', 'a')
     kwargs = {}
     level = NOTSET
     formatter = generic
@@ -267,14 +267,14 @@ The buildout has updated our INI file:
     ...
     [handler_accesslog]
     class = FileHandler
-    args = ('var/log/foo.log', 'a')
+    args = (r'var/log/foo.log', 'a')
     kwargs = {}
     level = DEBUG
     formatter = message
     <BLANKLINE>
     [handler_eventlog]
     class = FileHandler
-    args = ('var/log/bar.log', 'a')
+    args = (r'var/log/bar.log', 'a')
     kwargs = {}
     level = NOTSET
     formatter = generic


### PR DESCRIPTION
Backslash in path was interpreted as escape characters and resulted in an SyntaxError on eval.