### PR TITLE
fast-listen support multiple addresses

### DIFF
--- a/news/146.bugfix
+++ b/news/146.bugfix
@@ -1,0 +1,3 @@
+Fixed an issue that prevented the instance to start
+when http-address has multiple entries and http-fast-listen is on
+[ale-rt]


### PR DESCRIPTION
Fixed an issue that prevented the instance to start
when http-address has multiple entries and http-fast-listen is on

Fixes #146