### PR TITLE
first quick shot to improve the windows install 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -668,6 +668,22 @@ http-header-max-length
 The generated control script
 ============================
 
+Windows
+-------
+
+On the windows platform the ``bin/instance`` script as described below will not be generated, because it uses a Unix specific implementation.
+
+To run Plone start it with::
+
+  .\bin\runwsigi.exe -v .\parts\etc\wsgi.ini
+
+Or for development in debug mode use
+
+  .\bin\runwsigi.exe -v .\parts\etc\wsgi.ini
+
+The documentation for the extended Zope control script below does not apply.
+
+
 The `debug`, `console` and `run` commands
 -----------------------------------------
 

--- a/news/151.bugfix
+++ b/news/151.bugfix
@@ -1,0 +1,4 @@
+Generate working ``wsgi.ini`` on windows.
+Do not generate instance script.
+Need to use ``.\bin\runwsigi.exe -dv .\parts\etc\wsgi.ini`` on windows to start.
+[jensens]


### PR DESCRIPTION
see #144, on windows:

- Do not install instance scripts.
- Generate a working wsgi.ini ready for runwsgi
- add a note to the docs

- at the moment it does not does not respect ip/port (todo)