### PR TITLE
Added option clear-untrusted-proxy-headers, with default false.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,10 @@ Introduction
 
 .. image:: http://img.shields.io/travis/plone/plone.recipe.zope2instance.svg
    :target: https://travis-ci.org/plone/plone.recipe.zope2instance
-   
+
 .. image:: https://github.com/plone/plone.recipe.zope2instance/workflows/Test/badge.svg?branch=master
    :target: https://github.com/plone/plone.recipe.zope2instance/actions?query=workflow%3ATest+branch%3Amaster
-   
+
 This recipe creates and configures a Zope instance in parts.
 (Despite its name it nowadays only works for Zope 4+.) It also
 installs a control script, which is like zopectl, in the bin/ directory.
@@ -493,6 +493,17 @@ before-storage
 client-home
   Sets the clienthome for the generated instance.
   Defaults to ${buildout:directory}/var/<name of the section>.
+
+clear-untrusted-proxy-headers
+  This tells Waitress to remove any untrusted proxy headers
+  ("Forwarded", "X-Forwarded-For", "X-Forwarded-By",
+  "X-Forwarded-Host", "X-Forwarded-Port", "X-Forwarded-Proto").
+  The default in waitress 1 is false, but waitress 2 changes this to true.
+  We explicitly default to false.
+  When you set it to true, you may need to set other ``wsgi.ini`` options like
+  ``trusted_proxy_headers`` and ``trusted_proxy``.
+  Setting those is not supported by the recipe yet.
+  Used for WSGI only, not ZServer.
 
 default-zpublisher-encoding
   This controls what character set is used to encode unicode data that reaches

--- a/news/142.feature
+++ b/news/142.feature
@@ -1,0 +1,4 @@
+Added option ``clear-untrusted-proxy-headers``, with default false.
+See `waitress documentation <https://waitress.readthedocs.io/en/latest/arguments.html?highlight=clear_untrusted_proxy_headers>`_.
+Fixes a `deprecation warning <https://github.com/plone/plone.recipe.zope2instance/issues/142>`_.
+[maurits]

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -789,6 +789,8 @@ class Recipe(Scripts):
         sentry_event_level = options.get('sentry_event_level', 'ERROR')
         sentry_ignore = options.get('sentry_ignore', '')
 
+        clear_untrusted_proxy_headers = options.get('clear-untrusted-proxy-headers', 'false')
+
         pipeline.append('zope')
         pipeline = '\n    '.join(pipeline)
         wsgi_options = {
@@ -797,6 +799,7 @@ class Recipe(Scripts):
             'accesslog_kwargs': accesslog_kwargs,
             'accesslog_level': accesslog_level,
             'accesslog_name': accesslog_name,
+            'clear_untrusted_proxy_headers': clear_untrusted_proxy_headers,
             'event_handlers': event_handlers,
             'eventlog_args': eventlog_args,
             'eventlog_handler': eventlog_handler,
@@ -1368,12 +1371,14 @@ paste.server_factory = plone.recipe.zope2instance:main
 use = egg:plone.recipe.zope2instance#main
 %(fast-listen)slisten = %(http_address)s
 threads = %(threads)s
+clear_untrusted_proxy_headers = %(clear_untrusted_proxy_headers)s
 """
 
 wsgi_server_main_templates['win32'] = """\
 use = egg:waitress#main
 host = %(listen_ip)s
 port = %(listen_port)s
+clear_untrusted_proxy_headers = %(clear_untrusted_proxy_headers)s
 """
 
 wsgi_ini_template = """\

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -789,7 +789,9 @@ class Recipe(Scripts):
         sentry_event_level = options.get('sentry_event_level', 'ERROR')
         sentry_ignore = options.get('sentry_ignore', '')
 
-        clear_untrusted_proxy_headers = options.get('clear-untrusted-proxy-headers', 'false')
+        clear_untrusted_proxy_headers = options.get(
+            'clear-untrusted-proxy-headers', 'false'
+        )
 
         pipeline.append('zope')
         pipeline = '\n    '.join(pipeline)

--- a/src/plone/recipe/zope2instance/wsgischema.xml
+++ b/src/plone/recipe/zope2instance/wsgischema.xml
@@ -33,17 +33,17 @@
     <multikey name="mount-point" required="yes" attribute="mount_points"
               datatype=".mount_point">
       <description>
-       The mount point is a slash-separated path to a 
-       'Products.ZODBMountPoint.Mount.MountPoint' instance in Zope. If 
-       such an instance exists, it can mount an object (the mounted 
+       The mount point is a slash-separated path to a
+       'Products.ZODBMountPoint.Mount.MountPoint' instance in Zope. If
+       such an instance exists, it can mount an object (the mounted
        object) into Zope.
        By default, the object will be mounted at the same path in Zope (i.e.
        '/foo/bar' in the database will be mounted at '/foo/bar' in Zope).
 
        The object can be mounted at a different point using the
-       'virtual_path:real_path' syntax (e.g.  'mount-point /foo/bar:/bar' 
-       will mount the object at '/bar' in the database to '/foo/bar' in 
-       Zope). The name of the mount point ('bar') must be the same as 
+       'virtual_path:real_path' syntax (e.g.  'mount-point /foo/bar:/bar'
+       will mount the object at '/bar' in the database to '/foo/bar' in
+       Zope). The name of the mount point ('bar') must be the same as
        the mounted object.
 
        It is also possible to specify the root that should be used in the
@@ -377,6 +377,17 @@
      </description>
      <metadefault>unset</metadefault>
   </multikey>
+
+  <key name="clear-untrusted-proxy-headers" datatype="boolean"
+       default="on">
+     <description>
+     This tells Waitress to remove any untrusted proxy headers
+     ("Forwarded", "X-Forwarded-For", "X-Forwarded-By",
+     "X-Forwarded-Host", "X-Forwarded-Port", "X-Forwarded-Proto")
+     not explicitly allowed by trusted_proxy_headers.
+     </description>
+     <metadefault>on</metadefault>
+  </key>
 
   <key name="max-conflict-retries" datatype="integer" default="3"
        attribute="max_conflict_retries">


### PR DESCRIPTION
See [waitress documentation](https://waitress.readthedocs.io/en/latest/arguments.html?highlight=clear_untrusted_proxy_headers).
Fixes a [deprecation warning](https://github.com/plone/plone.recipe.zope2instance/issues/142).
Note that waitress 2 will change the default to true, but it looks like we would need to add other options then.