### PR TITLE
Restored ability to use own explicit version of zodb-temporary-storage.

### DIFF
--- a/news/93.bugfix
+++ b/news/93.bugfix
@@ -1,0 +1,2 @@
+Restored ability to use own explicit version of zodb-temporary-storage.
+[maurits]

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -661,8 +661,10 @@ class Recipe(Scripts):
 
         zodb_tmp_storage = options.get('zodb-temporary-storage', 'on')
         if zodb_tmp_storage.lower() in ('off', 'false', '0'):
+            # no temporary-storage snippet
             zodb_tmp_storage = ''
-        else:
+        elif zodb_tmp_storage.lower() in ('on', 'true', '1'):
+            # use default temporary-storage snippet
             zodb_tmp_storage = zodb_temporary_storage_template
         template = wsgi_conf_template if self.wsgi else zope_conf_template
 

--- a/src/plone/recipe/zope2instance/tests/zope2instance_tempstorage_off.rst
+++ b/src/plone/recipe/zope2instance/tests/zope2instance_tempstorage_off.rst
@@ -77,3 +77,105 @@ The generated configuration has no temporary storage section anymore:
     </zodb_db>
     python-check-interval 1000
 
+Leaving the option empty should have the same result,
+as this was previously the way to disable it::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... zodb-temporary-storage =
+    ... ''' % options)
+
+Let's run it::
+
+    >>> output = system(join('bin', 'buildout'))
+    >>> "Installing instance" in output
+    True
+
+    >>> WINDOWS or "Generated script" in output
+    True
+
+    >>> WINDOWS or "Generated interpreter" in output
+    True
+
+The generated configuration should be the same as from the previous run.
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> with open(os.path.join(instance, 'etc', 'zope.conf')) as fd:
+    ...     zope_conf2 = fd.read()
+    >>> zope_conf2 = zope_conf2.replace('\\', '/')
+    >>> zope_conf == zope_conf2
+    True
+
+
+Explicit ZODB temporary storage
+===============================
+
+You can also explicitly set an own ZODB temporary storage definition:
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = instance
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... eggs =
+    ... user = me:me
+    ... zodb-temporary-storage = <some config />
+    ... ''' % options)
+
+Let's run it::
+
+    >>> output = system(join('bin', 'buildout'))
+    >>> "Installing instance" in output
+    True
+
+    >>> WINDOWS or "Generated script" in output
+    True
+
+    >>> WINDOWS or "Generated interpreter" in output
+    True
+
+The generated configuration has our explicit temporary storage section:
+
+    >>> instance = os.path.join(sample_buildout, 'parts', 'instance')
+    >>> with open(os.path.join(instance, 'etc', 'zope.conf')) as fd:
+    ...     zope_conf = fd.read()
+    >>> zope_conf = zope_conf.replace('\\', '/')
+    >>> print(zope_conf)
+    %define INSTANCEHOME .../sample-buildout/parts/instance
+    instancehome $INSTANCEHOME
+    %define CLIENTHOME .../sample-buildout/var/instance
+    clienthome $CLIENTHOME
+    debug-mode off
+    security-policy-implementation C
+    verbose-security off
+    default-zpublisher-encoding utf-8
+    <environment>
+        CHAMELEON_CACHE .../var/cache
+    </environment>
+    <zodb_db main>
+        # Main database
+        cache-size 30000
+        # Blob-enabled FileStorage database
+        <blobstorage>
+          blob-dir .../sample-buildout/var/blobstorage
+          # FileStorage database
+          <filestorage>
+            path .../sample-buildout/var/filestorage/Data.fs
+          </filestorage>
+        </blobstorage>
+        mount-point /
+    </zodb_db>
+    <some config />
+    python-check-interval 1000
+


### PR DESCRIPTION
You used to be able to set `zodb-temporary-storage = <some config />` and have this config in the `site.zcml`.
Most important use of this was to let this empty, effectively disabling the temporary storage.
PR https://github.com/plone/plone.recipe.zope2instance/pull/93 changed this so you could do this in a more natural way, by setting `zodb-temporary-storage = false`.

But this (accidentally) removed the possibility for setting an explicit own version of the temporary storage snippet, and meant the only options now were false or true.
The documentation still mentions:

> If given, Zope's default temporary storage definition will be replaced by the lines of this parameter.