### PR TITLE
Make any ctl script python-dotenv (.env files) aware

### DIFF
--- a/news/162.feature
+++ b/news/162.feature
@@ -1,0 +1,2 @@
+Make any ctl script python-env aware
+[sneridagh]

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'ZEO',
         'waitress >= 1.2.0',
         'Paste',
+        'python-dotenv'
     ],
     extras_require={
         'test': [

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -944,7 +944,6 @@ def main(args=None):
     else:
         options = ZServerCtlOptions()
 
-
     options.add(name="no_request", short="R", long="no-request", flag=1)
     options.add(name="no_login", short="L", long="no-login", flag=1)
     options.add(name="object_path", short="O:", long="object-path=")

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -27,6 +27,7 @@ typed interactively is started. Use the action "help" to find out about
 available actions.
 """
 
+from dotenv import load_dotenv
 from pkg_resources import iter_entry_points
 from time import sleep
 from waitress.wasyncore import dispatcher
@@ -942,12 +943,20 @@ def main(args=None):
         options = WSGICtlOptions()
     else:
         options = ZServerCtlOptions()
+
+
     options.add(name="no_request", short="R", long="no-request", flag=1)
     options.add(name="no_login", short="L", long="no-login", flag=1)
     options.add(name="object_path", short="O:", long="object-path=")
     options.add(name="wsgi", short='w:', long='wsgi=')
     # Realize arguments and set documentation which is used in the -h option
     options.realize(args, doc=__doc__)
+
+    load_dotenv(os.path.join(options.directory, '..', '..', '.env'))
+
+    if (os.environ.get('PLONE_ENV')):
+        PLONE_ENV = os.environ.get('PLONE_ENV')
+        load_dotenv(os.path.join(options.directory, '..', '..', '.env.{}'.format(PLONE_ENV)))
 
     # Run the right command depending on whether we have ZServer
     options.interpreter = os.path.join(options.directory, 'bin', 'interpreter')


### PR DESCRIPTION
Adds python-dotenv dependency, adds two level of awareness:

loads `.env` file, if any
then if `PLONE_ENV` is present, loads the `.env.PLONE_ENV` file (if any)

So we can have a `.env.production` then running PLONE_ENV=production `.bin/instance fg` it loads the env file.

Volto is already `.env` files aware, it seems sensible that Plone also does it, specially after the @plone/installer-team decided to start using environment variables (a la docker) to setup the maximum number of things. ZConfig already allows configuration based in environment variables instead of hardcoded values, so it's the perfect match.