### PR TITLE
Fix `$PYTHONSTARTUP` file support for the debug command under Python 3

### DIFF
--- a/news/167.bugfix
+++ b/news/167.bugfix
@@ -1,0 +1,2 @@
+Fixed ``$PYTHONSTARTUP`` file support for the ``debug`` command under Python 3
+[dataflake]

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -796,11 +796,15 @@ console -- Run the program in the console.
         interactive_startup = (
             "import os;"
             "os.path.exists(os.environ.get('PYTHONSTARTUP', '')) "
-            "and execfile(os.environ['PYTHONSTARTUP']); del os;"
+            "and %s; del os;"
         )
+        if six.PY2:
+            exec_call = "execfile(os.environ['PYTHONSTARTUP'])"
+        else:
+            exec_call = "exec(open(os.environ['PYTHONSTARTUP']).read())"
         cmdline = self.get_startup_cmd(
             self.options.python,
-            interactive_startup,
+            interactive_startup % exec_call,
             pyflags='-i',
         )
         print('Starting debugger (the name "app" is bound to the top-level '


### PR DESCRIPTION
Fixes #167 

Support for `$PYTHONSTARTUP` for the `debug` command never worked under Python 3. This small PR fixes that.