### PR TITLE
enable constraints files for test suite

### DIFF
--- a/news/171.bugfix.rst
+++ b/news/171.bugfix.rst
@@ -1,0 +1,2 @@
+Fix unsupported syntax in the requirements files which prevented to evaluate
+the specified constraints during test runs [jugmac00].

--- a/requirements-testing-zope-4.txt
+++ b/requirements-testing-zope-4.txt
@@ -1,4 +1,5 @@
--e .[test] -c https://zopefoundation.github.io/Zope/releases/4.5.5/requirements-full.txt
+-e .[test]
+-c https://zopefoundation.github.io/Zope/releases/4.5.5/requirements-full.txt
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/requirements-testing-zope-5.txt
+++ b/requirements-testing-zope-5.txt
@@ -1,4 +1,5 @@
--e .[test] -c https://zopefoundation.github.io/Zope/releases/5.1.2/requirements-full.txt
+-e .[test]
+-c https://zopefoundation.github.io/Zope/releases/5.1.2/requirements-full.txt
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:


### PR DESCRIPTION
In the requirements files an unsupported syntax was used, which
prevented the constraints files from being evaluated.

ie you need to put every ``pip`` option on a single line.

If you put two on one line, only the first gets evaluated.

This fixes #171 