### PR TITLE
Fix `python-dotenv` dependency for Python 2 compatibility

### DIFF
--- a/news/181.bugfix
+++ b/news/181.bugfix
@@ -1,0 +1,1 @@
+- Fix `python-dotenv` dependency for Python 2 compatibility [dataflake] (#181)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "ZEO",
         "waitress >= 1.2.0",
         "Paste",
-        "python-dotenv",
+        "python-dotenv < 0.19",
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "ZEO",
         "waitress >= 1.2.0",
         "Paste",
-        "python-dotenv < 0.19",
+        "python-dotenv < 0.19",  # python 2 support
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
         "ZEO",
         "waitress >= 1.2.0",
         "Paste",
-        "python-dotenv < 0.19",  # python 2 support
+        'python-dotenv < 0.19; python_version<"3"',
+        'python-dotenv; python_version>="3"',
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Fixes #181 
