### PR TITLE
Fix CI

### DIFF
--- a/requirements-testing-zope-4.txt
+++ b/requirements-testing-zope-4.txt
@@ -1,5 +1,5 @@
 -e .[test]
--c https://zopefoundation.github.io/Zope/releases/4.5.5/requirements-full.txt
+-c https://zopefoundation.github.io/Zope/releases/4.7/requirements-full.txt
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/requirements-testing-zope-5.txt
+++ b/requirements-testing-zope-5.txt
@@ -1,5 +1,5 @@
 -e .[test]
--c https://zopefoundation.github.io/Zope/releases/5.1.2/requirements-full.txt
+-c https://zopefoundation.github.io/Zope/releases/5.4/requirements-full.txt
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/src/plone/recipe/zope2instance/ctl.py
+++ b/src/plone/recipe/zope2instance/ctl.py
@@ -884,19 +884,16 @@ console -- Run the program in the console.
         except Exception:
             print("usage: adduser <name> <password>")
             return
-        cmdline = (
-            self.get_startup_cmd(
-                self.options.python,
-                "import Zope2; "
-                "app = Zope2.app(); "
-                "result = app.acl_users._doAddUser("
-                "'%s', '%s', ['Manager'], []); "
-                "import transaction; "
-                "transaction.commit(); "
-                "print('Created user:', result)",
-            )
-            % (name, password)
-        )
+        cmdline = self.get_startup_cmd(
+            self.options.python,
+            "import Zope2; "
+            "app = Zope2.app(); "
+            "result = app.acl_users._doAddUser("
+            "'%s', '%s', ['Manager'], []); "
+            "import transaction; "
+            "transaction.commit(); "
+            "print('Created user:', result)",
+        ) % (name, password)
         os.system(cmdline)
 
     def help_adduser(self):

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -103,13 +103,10 @@ class Recipe(Scripts):
             options["initialization"] = ""
         options["initialization"] = options["initialization"] % options
 
-        self._include_site_packages = (
-            options.get(
-                "include-site-packages",
-                buildout["buildout"].get("include-site-packages", "false"),
-            )
-            not in ("off", "disable", "false")
-        )
+        self._include_site_packages = options.get(
+            "include-site-packages",
+            buildout["buildout"].get("include-site-packages", "false"),
+        ) not in ("off", "disable", "false")
 
         self.wsgi = True
         self.wsgi_config = os.path.join(options["location"], "etc", "wsgi.ini")

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,11 @@ deps =
 setenv =
     COVERAGE_FILE=.coverage.{envname}
 
+[testenv:py39]
+deps =
+    -rrequirements-testing-zope-5.txt
+    coverage
+
 [testenv:coverage]
 basepython = python2.7
 skip_install = true


### PR DESCRIPTION
- A new version of `black` introduced minor changes.
- Test with latests Zope 4/5 versions.
- Fix tox to let Python 3.9 test Zope 5 only. On GitHub Actions, Zope 5 is tested on a few more Python versions. Locally this fixes an error that makes no sense:

```
ERROR: Cannot install plone-recipe-zope2instance[test]==6.10.3.dev0
because these package versions have conflicting dependencies.

The conflict is caused by:
    plone-recipe-zope2instance[test] 6.10.3.dev0 depends on Zope>=4.0b1
    The user requested (constraint) zope==4.5.5
```

Note: I did not add a changelog entry for this internal change.