### PR TITLE
feat: add dos_protection config

### DIFF
--- a/news/191.feature
+++ b/news/191.feature
@@ -1,0 +1,1 @@
+add dos_protection config @mamico

--- a/src/plone/recipe/zope2instance/wsgischema.xml
+++ b/src/plone/recipe/zope2instance/wsgischema.xml
@@ -225,6 +225,33 @@
 
   </sectiontype>
 
+  <sectiontype name="dos_protection">
+
+    <description>Defines parameters for DOS attack protection</description>
+
+    <key name="form-memory-limit" datatype="byte-size" default="1MB">
+      <description>
+       The maximum size for each part in a multipart post request,
+       for the complete body in an urlencoded post request
+       and for the complete request body when accessed as bytes
+       (rather than a file).
+      </description>
+    </key>
+
+    <key name="form-disk-limit" datatype="byte-size" default="1GB">
+      <description>
+       The maximum size of a POST request body
+      </description>
+    </key>
+
+    <key name="form-memfile-limit" datatype="byte-size" default="4KB">
+      <description>
+       The value of form variables of type file with larger size
+       are stored on disk rather than in memory.
+      </description>
+    </key>
+  </sectiontype>
+
   <!-- end of type definitions -->
 
   <!-- schema begins  -->
@@ -552,5 +579,8 @@
    </description>
    <metadefault>off</metadefault>
   </key>
+
+  <section type="dos_protection" handler="dos_protection"
+           name="*" attribute="dos_protection" />
 
 </schema>


### PR DESCRIPTION
synchronize wsgischema changes from Zope, regarding `dos_protection`

see https://github.com/plone/Products.CMFPlone/issues/3848

example of zope.conf for increasing the form size limit

```
zope-conf-additional =
  <dos_protection>
    form-memory-limit 4MB
  </dos_protection>
```