### PR TITLE
Support setting Sentry max_value_length

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -377,6 +377,11 @@ sentry_ignore
   Set the (space separated list of) logger names that are ignored by Sentry.
   Available for WSGI only.
 
+sentry_max_value_length
+  Set the maximum size of traceback messages sent to Sentry. If your tracebacks
+  get truncated, increase this above the sentry-sdk default of 1024.
+  Available for WSGI only.
+
 Advanced logging options for WSGI
 ---------------------------------
 

--- a/news/193.feature
+++ b/news/193.feature
@@ -1,0 +1,1 @@
+Add support for setting max_value_length in Sentry init.

--- a/news/193.tests
+++ b/news/193.tests
@@ -1,0 +1,1 @@
+Update tox to support python 3.10 and 3.11.

--- a/src/plone/recipe/zope2instance/recipe.py
+++ b/src/plone/recipe/zope2instance/recipe.py
@@ -849,6 +849,7 @@ class Recipe(Scripts):
         sentry_level = options.get("sentry_level", "INFO")
         sentry_event_level = options.get("sentry_event_level", "ERROR")
         sentry_ignore = options.get("sentry_ignore", "")
+        sentry_max_value_length = options.get("sentry_max_value_length", "")
 
         profile = options.get("profile", "").strip() == "on"
         if profile:
@@ -916,6 +917,7 @@ class Recipe(Scripts):
             "sentry_event_level": sentry_event_level,
             "sentry_ignore": sentry_ignore,
             "sentry_level": sentry_level,
+            "sentry_max_value_length": sentry_max_value_length,
             "threads": options.get("threads", 4),
             "profile_log_filename": profile_log_filename,
             "profile_cachegrind_filename": profile_cachegrind_filename,
@@ -1517,6 +1519,7 @@ dsn = %(sentry_dsn)s
 level = %(sentry_level)s
 event_level = %(sentry_event_level)s
 ignorelist = %(sentry_ignore)s
+max_value_length = %(sentry_max_value_length)s
 
 [filter:profile]
 use = egg:repoze.profile

--- a/src/plone/recipe/zope2instance/sentry.py
+++ b/src/plone/recipe/zope2instance/sentry.py
@@ -5,15 +5,21 @@ import logging
 import sentry_sdk
 
 
-def sdk_init(global_conf, dsn, level="INFO", event_level="ERROR", ignorelist=""):
+def sdk_init(global_conf, dsn, level="INFO", event_level="ERROR", ignorelist="", max_value_length=""):
     sentry_logging = LoggingIntegration(
         level=logging.__dict__[level], event_level=logging.__dict__[event_level]
     )
     for logger in ignorelist.split():
         ignore_logger(logger)
+    if max_value_length == "":
+        # Fall back to sentry-sdk default of 1024
+        max_value_length = None
+    else:
+        # This will raise on startup if the provided value is invalid. Fine.
+        max_value_length = int(max_value_length)
 
     def filter(app):
-        sentry_sdk.init(dsn=dsn, integrations=[sentry_logging])
+        sentry_sdk.init(dsn=dsn, integrations=[sentry_logging], max_value_length=max_value_length)
         return app
 
     return filter

--- a/src/plone/recipe/zope2instance/tests/wsgi.rst
+++ b/src/plone/recipe/zope2instance/tests/wsgi.rst
@@ -469,6 +469,7 @@ The buildout has updated our INI file:
     level = INFO
     event_level = ERROR
     ignorelist =
+    max_value_length =
     ...
     [pipeline:main]
     pipeline =
@@ -497,6 +498,7 @@ Let's update our buildout with some Sentry options:
     ... sentry_level = DEBUG
     ... sentry_event_level = WARNING
     ... sentry_ignore = waitress.queue foo
+    ... sentry_max_value_length = 2048
     ... ''' % options)
 
 Let's run it::
@@ -522,6 +524,7 @@ The buildout has updated our INI file:
     level = DEBUG
     event_level = WARNING
     ignorelist = waitress.queue foo
+    max_value_length = 2048
     ...
     [pipeline:main]
     pipeline =

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist =
     py37,
     py38,
     py39,
+    py310,
+    py311,
     flake8,
     black,
     isort
@@ -30,6 +32,16 @@ deps =
     -rrequirements-testing-zope-5.txt
     coverage
 
+[testenv:py310]
+deps =
+    -rrequirements-testing-zope-5.txt
+    coverage
+
+[testenv:py311]
+deps =
+    -rrequirements-testing-zope-5.txt
+    coverage
+
 [testenv:coverage]
 basepython = python2.7
 skip_install = true
@@ -41,6 +53,8 @@ depends =
     py37
     py38
     py39
+    py310
+    py311
 setenv =
     COVERAGE_FILE=.coverage
 commands =


### PR DESCRIPTION
My Sentry tracebacks routinely get truncated:

![image](https://github.com/plone/plone.recipe.zope2instance/assets/122351/9c844d6f-8bba-456f-8c38-a835c325e1db)

Previously, we used a monkeypatch to work around that:
```
 initialization =
     import sentry_sdk
     sentry_sdk.utils.MAX_STRING_LENGTH = 4096
```

The upstream change https://github.com/getsentry/sentry-python/commit/5478df29e9a25cb1e8e84f7e045d31e0b10030c7 both invalidates that monkeypatch and obviates the need for it, by adding [proper API support](https://github.com/getsentry/sentry-python/blob/d9d87998029fb0ef2bfe933cea0b69bfee60ed51/sentry_sdk/consts.py#L309) for accepting larger tracebacks.

This PR adds support for the newly introduced init option of `max_value_length` here.

Additionally, it brings `tox.ini` in line with the Python versions declared as supported in setup.py