### PR TITLE
Remove obsolete attention admonition from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,12 +26,6 @@ You can use it with a part like this::
   eggs = my.distribution
   zcml = my.distribution
 
-.. ATTENTION::
-   This release is targeted at Plone 5.2, ZODB 5, Zope 4 and Zope 5, and
-   Python 2.7 and 3.5-3.9. If you are using this recipe with earlier versions,
-   you should use one of the releases from the 4.x series.
-
-
 .. contents:: **Contents**
 
 


### PR DESCRIPTION
Remove obsolete attention admonition. The `master` branch supports Plone 6.x.