### PR TITLE
Support for Zope option `enable-xmlrpc`

### DIFF
--- a/news/200.feature
+++ b/news/200.feature
@@ -1,0 +1,1 @@
+support for Zope option `enable-xmlrpc`

--- a/src/plone/recipe/zope2instance/wsgischema.xml
+++ b/src/plone/recipe/zope2instance/wsgischema.xml
@@ -580,6 +580,22 @@
    <metadefault>off</metadefault>
   </key>
 
+  <key name="enable-xmlrpc" datatype="boolean" default="on">
+    <description>
+     Turn Zope's built-in XML-RPC support on or off.
+
+     Zope has built-in support for XML-RPC requests. It will attempt to use
+     XML-RPC for POST-requests with Content-Type header 'text/xml'. By
+     default the XML-RPC request support is enabled.
+
+     Due to the limited use of XML-RPC nowadays and its potential for abuse
+     by malicious actors you can set this directive to 'off' to turn off
+     support for XML-RPC. Incoming XML-RPC requests will be refused with
+     a BadRequest (HTTP status 400) response.
+    </description>
+    <metadefault>on</metadefault>
+  </key>
+
   <section type="dos_protection" handler="dos_protection"
            name="*" attribute="dos_protection" />
 


### PR DESCRIPTION
Fixes #200 

This PR adds minimal support for Zope option `enable-xmlrpc`. For now it is OK to just have it in the schema so that the option can be put into zope-conf-additional and sites running on plone.recipe.zope2instance don't completely fail when you try starting them with this option.

IMHO using this new option to disable XML-RPC processing is a good idea for every "normal" site, "normal" being those that do not use XML-RPC. It reduces the attack surface.