### PR TITLE
Add official support for Python 3.13.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,6 +20,7 @@ jobs:
         - "3.10"
         - "3.11"
         - "3.12"
+        - "3.13"
         os:
         - ubuntu-22.04
         - windows-2022
@@ -39,12 +40,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-test
       - name: Run black code style check
-        if: ${{ matrix.python-version == '3.12' }}
+        if: ${{ matrix.python-version == '3.13' }}
         run: |
           pip install black
           black --check src setup.py
       - name: Run isort code style check
-        if: ${{ matrix.python-version == '3.12' }}
+        if: ${{ matrix.python-version == '3.13' }}
         run: |
           pip install isort
           isort --check-only --df src setup.py

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,2 @@
+zc.buildout==4.1.4
+setuptools==75.8.2

--- a/news/202.breaking
+++ b/news/202.breaking
@@ -1,0 +1,1 @@
+Drop support for Python 3.8.

--- a/news/202.feature
+++ b/news/202.feature
@@ -1,0 +1,1 @@
+Add official support for Python 3.13.

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,5 +1,5 @@
 -e .[test]
--c https://zopefoundation.github.io/Zope/releases/5.10/requirements-full.txt
+-c https://zopefoundation.github.io/Zope/releases/5.12/requirements-full.txt
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,5 +1,6 @@
 -e .[test]
 -c https://zopefoundation.github.io/Zope/releases/5.12/requirements-full.txt
+-c constraints.txt
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 
 name = "plone.recipe.zope2instance"
-version = "7.2.0.dev0"
+version = "8.0.0.dev0"
 
 setup(
     name=name,
@@ -23,11 +23,11 @@ setup(
         "Framework :: Plone",
         "Framework :: Plone :: 6.0",
         "Framework :: Plone :: 6.1",
+        "Framework :: Plone :: 6.2",
         "Framework :: Plone :: Core",
         "Framework :: Zope :: 5",
         "License :: OSI Approved :: Zope Public License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     package_dir={"": "src"},
     namespace_packages=["plone", "plone.recipe"],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         "zc.buildout",
         "setuptools",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 
 name = "plone.recipe.zope2instance"
-version = "7.1.3.dev0"
+version = "7.2.0.dev0"
 
 setup(
     name=name,
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     packages=find_packages("src"),

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py310,
     py311,
     py312,
+    py313,
     flake8,
     black,
     isort
@@ -25,7 +26,7 @@ setenv =
     COVERAGE_FILE=.coverage.{envname}
 
 [testenv:coverage]
-basepython = python3.12
+basepython = python3.13
 skip_install = true
 deps = coverage
 depends =
@@ -34,6 +35,7 @@ depends =
     py310
     py311
     py312
+    py313
 setenv =
     COVERAGE_FILE=.coverage
 commands =
@@ -44,19 +46,19 @@ commands =
     coverage report
 
 [testenv:flake8]
-basepython = python3.12
+basepython = python3.13
 skip_install = true
 deps = flake8
 commands = flake8 --ignore=E203 --max-line-length=88 --doctests src setup.py
 
 [testenv:black]
-basepython = python3.12
+basepython = python3.13
 skip_install = true
 deps = black
 commands = black --check src setup.py
 
 [testenv:isort]
-basepython = python3.12
+basepython = python3.13
 skip_install = true
 deps = isort
 commands = isort --check-only --df src setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py38,
     py39,
     py310,
     py311,
@@ -15,7 +14,7 @@ skip_missing_interpreters = False
 
 [testenv]
 usedevelop = true
-install_command = python -m pip install {opts} {packages}
+#install_command = python -m pip install {opts} {packages}
 commands =
     coverage run {envbindir}/zope-testrunner --test-path=src []
 extras = test
@@ -30,7 +29,6 @@ basepython = python3.13
 skip_install = true
 deps = coverage
 depends =
-    py38
     py39
     py310
     py311

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ skip_missing_interpreters = False
 
 [testenv]
 usedevelop = true
-#install_command = python -m pip install {opts} {packages}
 commands =
     coverage run {envbindir}/zope-testrunner --test-path=src []
 extras = test


### PR DESCRIPTION
Fixes #202 

@mauritsvanrees I looked at how you added Python 3.12 support in #195. I also updated the test requirements to use Zope 5.12 version pins instead of 5.10. Let me know if that's OK or if you want that reverted back to 5.10.