### PR TITLE
Check for presence of Products.CMFPlone with multiple keys.

### DIFF
--- a/news/205.bugfix
+++ b/news/205.bugfix
@@ -1,0 +1,3 @@
+Check for presence of Products.CMFPlone with multiple keys.
+This is needed, depending on the used `zc.buildout` and `setuptools` versions.
+[maurits]


### PR DESCRIPTION
Depending on the setuptools and zc.buildout versions used, we may need a different key. We no longer check for minimum version 6.0.0a1, because the recipe only supports Plone 6 anyway.

This fixes a problem where my instance could not start, because `parts/instance/etc/zope.conf` contained unsupported configuration for a temporarystorage. The error was:

```
$ bin/instance fg
Error: unknown type name: 'temporarystorage'
(line 27 in file:///Users/maurits/tmp/ale/parts/instance/etc/zope.conf)
For help, use bin/instance -h
```

Note: this removes one usage of `pkg_resources`, but there are a few more lingering, which would be good to get rid of.  But that can be done in a separate PR.

If anyone needs a workaround: set `zodb-temporary-storage = off` in the recipe options.