### PR TITLE
Remove class-factory from wsgischema.xml for Zope > 6.0 support

### DIFF
--- a/news/212.bugfix
+++ b/news/212.bugfix
@@ -1,0 +1,4 @@
+Remove class-factory from wsgischema.xml for Zope > 6.0 support.
+
+See `issue 212 <https://github.com/plone/plone.recipe.zope2instance/issues/212>`_.
+[perrinjerome]

--- a/src/plone/recipe/zope2instance/wsgischema.xml
+++ b/src/plone/recipe/zope2instance/wsgischema.xml
@@ -76,17 +76,6 @@
       </description>
     </key>
 
-    <key default="Zope2.Startup.datatypes.simpleClassFactory"
-         name="class-factory"
-         datatype=".importable_name"
-    >
-      <description>
-       Change the class factory function a database uses on a
-       per-database basis to support different class factory policy.
-       Use a Python dotted-path name to specify the class factory function.
-      </description>
-    </key>
-
     <key name="container-class"
          datatype="string"
     >


### PR DESCRIPTION
This was also removed from the original wsgischema from Zope in https://github.com/zopefoundation/Zope/pull/1290

Fixes #212

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #212 

----

I tested that zope starts when running `uv run --with zc.buildout buildout -v  && ./bin/zopeinstance fg`, first with a buildout on the latest released Zope, 6.0:

```ini
## buildout from https://zope.readthedocs.io/en/latest/INSTALL.html#using-plone-recipe-zope2instance
[buildout]
extends =
    https://zopefoundation.github.io/Zope/releases/6.0/versions-prod.cfg
parts =
    zopeinstance

[zopeinstance]
recipe = plone.recipe.zope2instance
eggs =
user = admin:adminpassword
http-address = 8080
zodb-temporary-storage = off
###


## develop plone.recipe.zope2instance on this branch
[buildout]
develop =
    ../plone.recipe.zope2instance
[versions]
plone.recipe.zope2instance =
```

and with the next versions of ZODB and Zope:


```ini
## buildout from https://zope.readthedocs.io/en/latest/INSTALL.html#using-plone-recipe-zope2instance
[buildout]
extends =
    https://zopefoundation.github.io/Zope/releases/6.0/versions-prod.cfg
parts =
    zopeinstance

[zopeinstance]
recipe = plone.recipe.zope2instance
eggs =
user = admin:adminpassword
http-address = 8080
zodb-temporary-storage = off
###


## develop plone.recipe.zope2instance on this branch and Zope on current master branch
[buildout]
develop =
    ../plone.recipe.zope2instance
    ../Zope
[versions]
plone.recipe.zope2instance =
Zope =

## next ZODB version
[versions]
ZODB = 6.3
```

and zope starts in both cases
