### PR TITLE
Update WSGI schema.

### DIFF
--- a/news/+3e44a0f3.feature.rst
+++ b/news/+3e44a0f3.feature.rst
@@ -1,0 +1,1 @@
+Update WSGI schema to match the one from Zope 6.2.  [maurits]

--- a/src/plone/recipe/zope2instance/wsgischema.xml
+++ b/src/plone/recipe/zope2instance/wsgischema.xml
@@ -262,17 +262,54 @@
 
   <sectiontype name="dos_protection">
 
-    <description>Defines parameters for DOS attack protection</description>
+    <description>Options for DOS attack protection.
+
+       These options limit the amount of memory and disk resources for
+       the request processing by Zope itself
+       (in contrast to that by the application or the frontend WSGI server).
+
+       Note that the WSGI server (or WSGI middleware) may already have
+       consumed similar resources. Those resources, too, should
+       likely get limited by corresponding configuration options.
+
+       Zope's own request processing consists of the determination
+       of the request parameters and access to the request body.
+
+       Request parameters can come from a query string and
+       the body of POST requests with content type
+       "application/x-www-form-urlencoded" or "multipart/form-data".
+       The options limit essentially the resources used
+       for parameter values from those POST requests.
+       form-urlencoded requests are assumed to contain only
+       small parameter values; for them, the complete body size is limited.
+       "multipart/form-data" requests are typically used
+       to upload (potentially) large files. For them,
+       small values are held in memory while large values
+       are stored on disk. An option controls when to switch
+       from memory to disk storage. Other options limit
+       the total memory and disk amount for the parameter values.
+
+       The protection options limit the resources used
+       for the raw request parameter values. For non file values
+       Zope maintains in addition preprocessed values;
+       they usually need memory resources in the same order
+       as the corresponding raw parameter values.
+
+       Zope provides access to the request body via
+       `request["BODY"]` and `request["BODYFILE"]`. The former
+       accesses the body as bytes and is limited; the latter
+       provides access via a file API and is not limited.
+    </description>
 
     <key default="1MB"
          name="form-memory-limit"
          datatype="byte-size"
     >
       <description>
-       The maximum size for each part in a multipart post request,
-       for the complete body in an urlencoded post request
-       and for the complete request body when accessed as bytes
-       (rather than a file).
+       Limits the total amount of memory for all parameter values held in
+       memory.
+       Limits the size of form-urlencoded request bodies.
+       Limits the size of request bodies accessed via `request["BODY"]`.
       </description>
     </key>
 
@@ -281,7 +318,8 @@
          datatype="byte-size"
     >
       <description>
-       The maximum size of a POST request body
+       Limits the total amount of disk space used for parameter values
+       stored on disk.
       </description>
     </key>
 
@@ -290,11 +328,22 @@
          datatype="byte-size"
     >
       <description>
-       The value of form variables of type file with larger size
-       are stored on disk rather than in memory.
+       Specifies the parameter value size at which its storage
+       switches from memory to disk.
+      </description>
+    </key>
+
+    <key default="1024"
+         name="form-part-limit"
+         datatype="integer"
+    >
+      <description>
+        Limits the maximum number of parameters or form fields. Larger
+        forms are blocked by the underlying field parser.
       </description>
     </key>
   </sectiontype>
+
 
   <!-- end of type definitions -->
 
@@ -686,7 +735,7 @@
     <metadefault>off</metadefault>
   </key>
 
-  <key default="on"
+  <key default="off"
        name="enable-xmlrpc"
        datatype="boolean"
   >
@@ -694,12 +743,11 @@
      Turn Zope's built-in XML-RPC support on or off.
 
      Zope has built-in support for XML-RPC requests. It will attempt to use
-     XML-RPC for POST-requests with Content-Type header 'text/xml'. By
-     default the XML-RPC request support is enabled.
+     XML-RPC for POST-requests with Content-Type header 'text/xml'.
 
-     Due to the limited use of XML-RPC nowadays and its potential for abuse
-     by malicious actors you can set this directive to 'off' to turn off
-     support for XML-RPC. Incoming XML-RPC requests will be refused with
+     By default XML-RPC request support is disabled due to the limited
+     use of the protocol nowadays and its potential for abuse by malicious
+     actors. When disabled, incoming XML-RPC requests will be refused with
      a BadRequest (HTTP status 400) response.
     </description>
     <metadefault>on</metadefault>


### PR DESCRIPTION
This takes over changes from [`wsgischema.xml` from Zope](https://github.com/zopefoundation/Zope/blob/master/src/Zope2/Startup/wsgischema.xml):

* Update descriptions for the sectiontype `dos_protection`.
* A new `form-part-limit` key in this `dos_protection` sectiontype.
* Set the `enable-xmlrpc` default to `off`.  This matches the change in Zope 6.2 published today.

Differences between `wsgischema.xml` from Zope and our own:

* We run `zpretty` over it, so layout and white spaces are a bit different.
* We define an extra `sectiontype` with name `zoperunner`.
* We have an extra section `runner`, which is an instance of our extra sectiontype `zoperunner`.
* We have an extra key `clear-untrusted-proxy-headers` for `waitress`, default `on`.
